### PR TITLE
Remove unnecessary code related to pipeline vault from prepare-ocp4-aws-config.yml

### DIFF
--- a/prepare-ocp4-aws-config.yml
+++ b/prepare-ocp4-aws-config.yml
@@ -1,23 +1,33 @@
----
-- name: Prepare OCP 4.1 configuration for installation on AWS
-  hosts: all
+# Extra_vars for the running this playbook
+# 1. cluster_name: Name of the cluster to be provisioned
+# 2. aws_region: region on which the ocp_cluster needs to be deployed
+# 3. ocp_install_directory: Directory in which the cluster config files are generated
+#                           by default it is fetched from pipleline_repo_path
+# 4. ocp_install_config_template: ocp_config file template path
+# 5. pull_secret_file: path to file containing pull secret dictionary (required)
+# 6. ssh_key_file: path to file containing ssh_key_file (required)
+- name: "Prepare OCP 4.x configuration for installation on AWS"
+  hosts: localhost
   become: false
   gather_facts: false
+  pre_tasks:
+    # set the default variable using set_fact
+    - name: "Set default varibles such that they can be overridden by extra-vars and environment variables"
+      set_fact:
+        cluster_name: "{{ cluster_name | default('test-cluster') }}"
+        aws_region: "{{ aws_region | default('us-east-2') }}"
 
-  vars_files:
-    - "{{ playbook_dir }}/../../../config/ansible/vault.yml"
-
-  vars:
-    cluster_name: "test-cluster"
-    aws_region: "us-east-2"
-
+    - name: "Set OCP install directory"
+      # Note: all the set_fact variables are fetched from extra-vars passed to playbook
+      # if the variables are not found they would be assuming the default variables
+      set_fact:
+        ocp_install_directory: "{{ ocp_install_directory | default(playbook_dir) }}"
+        ocp_install_config_template: "{{ ocp_install_config_template |
+                                         default(playbook_dir+'/install-config.yaml.j2') }}"
   tasks:
-    - set_fact:
-        ocp_install_directory: "{{ lookup('env', 'WORKSPACE') }}/operators/ocp-cluster-deployment/{{ cluster_name }}"
-
     - name: "Ensure that the ocp install directory exists and is empty"
       file:
-        path: "{{ ocp_install_directory }}"
+        path: "{{ ocp_install_directory }}/{{ cluster_name }}"
         state: "{{ item }}"
       with_items:
         - absent
@@ -25,32 +35,27 @@
 
     - name: "Inject cluster name: {{ cluster_name }} and region: {{ aws_region }} into the install config"
       template:
-        src: "{{ lookup('env', 'WORKSPACE') }}/operators/ocp-cluster-deployment/install-config.yaml.j2"
-        dest: "{{ ocp_install_directory }}/install-config.yaml"
+        src: "{{ ocp_install_config_template }}"
+        dest: "{{ ocp_install_directory }}/{{ cluster_name }}/install-config.yaml"
 
+    - name: Read pull_secret_file
+      shell: "cat {{ pull_secret_file }}"
+      register: pull_secret_contents
+      when: pull_secret_file is defined and ssh_key_file is defined
+    - name: Read ssh_key_file
+      shell: "cat {{ ssh_key_file }}"
+      register: ssh_key_file_contents
+      when: pull_secret_file is defined and ssh_key_file is defined
+    - name: "Prepare the dictionary"
+      set_fact:
+        secret_dict: "pullSecret: '{{ pull_secret_contents.stdout }}'\nsshKey: '{{ ssh_key_file_contents.stdout }}'"
+      no_log: true
+      when: pull_secret_file is defined and ssh_key_file is defined
     - name: "Inject secrets into the install-config"
       blockinfile:
-        path: "{{ ocp_install_directory }}/install-config.yaml"
-        block: "{{ cvp_vault.ocp_40_secrets | to_nice_yaml }}"
+        path: "{{ ocp_install_directory }}/{{ cluster_name }}/install-config.yaml"
+        block: "{{ secret_dict }}"
         insertafter: EOF
         marker: ""
       no_log: true
-
-    - file:
-        path: "{{ lookup('env', 'HOME') }}/.aws"
-        state: directory
-        mode: 0700
-
-    - copy:
-        content: "{{ cvp_vault.aws_credentials }}"
-        dest: "{{ lookup('env', 'HOME') }}/.aws/credentials"
-
-    - file:
-        path: "{{ lookup('env', 'HOME') }}/.ssh"
-        state: directory
-        mode: 0700
-
-    - copy:
-        content: "{{ cvp_vault.ssh_private_key }}"
-        dest: "{{ lookup('env', 'HOME') }}/.ssh/private_key"
-        mode: 0600
+      when: pull_secret_file is defined and ssh_key_file is defined


### PR DESCRIPTION
The following commit will remove all the unnecessary code from
prepare-ocp4-aws-config.yml since the code related to creation
of the aws credentials and injecting sshkeys is moved to pipeline
repo. Hence they are no longer required inside the playbook.
Further, This commit makes the playbook run without any dependency to
pipeline repo and vault.

