### PR TITLE
Add the operator bundle data validation role using operator-sdk

### DIFF
--- a/local-test-operator-bundle.yml
+++ b/local-test-operator-bundle.yml
@@ -32,3 +32,7 @@
     - name: "Parse the operator bundle image, manifest and metadata"
       include_role:
         name: parse_operator_bundle
+
+    - name: "Validate the operator manifest and metadata using operator-sdk"
+      include_role:
+        name: validate_operator_bundle

--- a/roles/validate_operator_bundle/defaults/main.yml
+++ b/roles/validate_operator_bundle/defaults/main.yml
@@ -1,0 +1,4 @@
+work_dir: /tmp/operator-test
+operator_work_dir: /tmp/operator-test/operator-files
+operator_sdk_bin_path: operator-sdk
+check_validation_result: true

--- a/roles/validate_operator_bundle/tasks/main.yml
+++ b/roles/validate_operator_bundle/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: "Remove any previous validation results"
+  shell: "rm -f {{ work_dir }}/validation-*"
+
+- name: "Output the operator-sdk version"
+  shell: "{{ operator_sdk_bin_path }} version"
+  register: sdk_version_result
+
+- name: "Output the operator-sdk version to a debug file"
+  copy:
+    content: "{{ sdk_version_result.stdout }}"
+    dest: "{{ work_dir }}/validation-version.txt"
+  when: sdk_version_result.stdout is defined
+
+- name: "Validate the operator bundle manifest and metadata with operator-sdk bundle validate"
+  shell: "{{ operator_sdk_bin_path }} bundle validate --verbose {{ operator_work_dir }} > {{ work_dir}}/validation-output.txt 2>&1"
+  register: sdk_validation_result
+  ignore_errors: true
+
+- name: "Output the return code of operator-sdk bundle validate command to a debug file"
+  copy:
+    content: "{{ sdk_validation_result.rc }}"
+    dest: "{{ work_dir }}/validation-rc.txt"
+  when: sdk_validation_result.rc is defined
+
+- name: "Fail if the operator didn't satisfy the operator-sdk validation test"
+  fail:
+    msg: 'Operator sdk validation test failed, check validation-output.txt for more details'
+  when:
+    - check_validation_result|bool
+    - sdk_validation_result.rc != 0

--- a/validate-operator-bundle.yml
+++ b/validate-operator-bundle.yml
@@ -1,0 +1,19 @@
+---
+- name: Validate the operator bundle image data with operator-sdk
+  hosts: all
+  become: false
+  gather_facts: false
+
+  vars:
+    work_dir: "{{ lookup('env', 'WORKSPACE') }}"
+    operator_work_dir: "/home/jenkins/agent/test-operator"
+    testing_bin_path: "/usr/local/bin"
+    jq_bin_path: "/usr/bin/jq"
+    yq_bin_path: "/usr/local/bin/yq"
+    operator_sdk_bin_path: "/usr/local/bin/operator-sdk"
+    check_validation_result: false
+
+  tasks:
+    - name: "Validate the operator bundle image data with operator-sdk"
+      include_role:
+        name: validate_operator_bundle


### PR DESCRIPTION
* Add the validate-operator-bundle role to run on unpacked bundle data
* Add the role to the new local-test-operator-bundle playbook
* Add the validate-operator-bundle playbook for Jenkins pipeline usage