### PR TITLE
Extend playbooks for upstream

### DIFF
--- a/cleanup-operator-resources.yml
+++ b/cleanup-operator-resources.yml
@@ -6,7 +6,7 @@
 
   vars:
     openshift_namespace: "test-operator"
-    oc_bin_path: "oc"
+    oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
     kubeconfig_path: ""
     crd_paths: []
     work_dir: "{{ lookup('env', 'WORKSPACE') }}"

--- a/deploy-olm-operator.yml
+++ b/deploy-olm-operator.yml
@@ -15,7 +15,7 @@
     olm_operator_files_path: "{{ work_dir }}/olm-operator-files"
     quay_token: "{{ cvp_vault.quay_token }}"
     quay_namespace: "cvpops"
-    oc_bin_path: "oc"
+    oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
     jq_bin_path : "/usr/bin/jq"
     yq_bin_path: "/usr/local/bin/yq"
     testing_bin_path: "/usr/local/bin"
@@ -32,7 +32,7 @@
       until: login_result.rc == 0
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      when: openshift_url is defined
+      when: openshift_url is defined and ((distro_type is undefined) or (distro_type != "upstream"))
 
     - name: "Parse operator metadata needed to run the tests"
       include_role:

--- a/local-test-operator.yml
+++ b/local-test-operator.yml
@@ -17,20 +17,25 @@
     work_dir: "/tmp/operator-test"
     testing_bin_path: "{{ work_dir }}/bin"
     current_channel: '' # Added to avoid a potential bug with undefined variables
+    distro_type: "{{ DISTRO_TYPE | default('') }}"
 
   tasks:
     - set_fact:
+        distro_type: "{{ DISTRO_TYPE | default('') }}"
         operator_work_dir: "{{ work_dir }}/operator-files"
         olm_operator_files_path: "{{ work_dir }}/olm-operator-files"
         scorecard_cr_dir: "{{ work_dir }}/scorecard-cr-files"
         kube_objects_dir: "{{ work_dir }}/kube_objects"
         testing_bin_path: "{{ work_dir }}/bin"
-        oc_bin_path: "{{ testing_bin_path }}/oc"
+        oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else \"{{ testing_bin_path }}/oc\" }}"
         jq_bin_path: "{{ testing_bin_path }}/jq"
         yq_bin_path: "{{ testing_bin_path }}/yq"
         go_bin_path: "{{ testing_bin_path }}/go/bin/go"
         operator_sdk_bin_path: "{{ testing_bin_path }}/operator-sdk"
         offline_cataloger_bin_path: "offline-cataloger"
+        KIND_ver: "{{ KIND_VER | default('') }}"
+        KIND_bin_path: "{{ testing_bin_path }}/kind"
+        KIND_kube_ver: "{{ KIND_KUBE_VER | default('') }}"
 
     - name: "Clear the operator working directory"
       file:
@@ -54,126 +59,139 @@
         name: install_operator_prereqs
       when: run_prereqs|bool
 
-    - name: "Run operator-courier nest to copy the operator metadata in nested format to the work dir"
-      shell: "operator-courier nest {{ operator_dir }} {{ operator_work_dir }}"
-
-    - name: "Parse operator metadata needed to run the tests"
+    - name: "Install catalog prerequisites"
       include_role:
-        name: parse_operator_metadata
+        name: install_docker
+      when: distro_type == "upstream"
 
-    - name: "Run linting tests with operator-courier verify on the deployed operator"
+    - name: "Build upstream catalog"
       include_role:
-        name: operator_courier_verify
-      when: run_lint|bool
+        name: build_upstream_catalog
+      when: distro_type == "upstream"
 
-    - name: "Run catalog initialization test on operator metadata"
-      include_role:
-        name: operator_catalog_initialization_test
-      when: run_catalog_init|bool
-
-    - name: "Operator deployment and scorecard/imagesource tests"
+    - name: "Openshift only"
       block:
-        - name: "Inject operator scorecard data into the operator metadata"
+        - name: "Run operator-courier nest to copy the operator metadata in nested format to the work dir"
+          shell: "operator-courier nest {{ operator_dir }} {{ operator_work_dir }}"
+
+        - name: "Parse operator metadata needed to run the tests"
           include_role:
-            name: inject_scorecard_metadata
-          when: run_scorecard|bool
+            name: parse_operator_metadata
 
-        - name: "Get all registry images on the OpenShift cluster before deploying the operator"
-          shell: "{{ oc_bin_path }} get is --all-namespaces -o json | jq '.items[].spec.tags[] | select(.from.kind == \"DockerImage\") | .from.name' --raw-output | sort -u"
-          register: os_registry_is_result_before
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
-          no_log: true
-
-        - name: "Get all pod images on the OpenShift cluster before deploying the operator"
-          shell: "{{ oc_bin_path }} get pods --all-namespaces -o json | jq '.items[].spec.containers[].image' --raw-output | sort -u"
-          register: os_pod_is_result_before
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
-          no_log: true
-
-        - set_fact:
-            openshift_images_before: " {{ os_registry_is_result_before.stdout_lines }} + {{ os_pod_is_result_before.stdout_lines }}"
-
-        - name: "Deploy the operator on the OpenShift 4.0 cluster with OLM"
+        - name: "Run linting tests with operator-courier verify on the deployed operator"
           include_role:
-            name: deploy_olm_operator
-          when: run_deploy|bool
+            name: operator_courier_verify
+          when: run_lint|bool
 
-        - name: "Get all openshift registry images"
-          shell: "{{ oc_bin_path }} get is --all-namespaces -o json | jq '.items[].spec.tags[] | select(.from.kind == \"DockerImage\") | .from.name' --raw-output | sort -u"
-          register: os_registry_is_result_after
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
-          no_log: true
+        - name: "Run catalog initialization test on operator metadata"
+          include_role:
+            name: operator_catalog_initialization_test
+          when: run_catalog_init|bool
 
-        - name: "Get all OpenShift pod images"
-          shell: "{{ oc_bin_path }} get pods --all-namespaces -o json | jq '.items[].spec.containers[].image' --raw-output | sort -u"
-          register: os_pod_is_result_after
-          environment:
-            KUBECONFIG: "{{ kubeconfig_path }}"
-          no_log: true
-
-        - set_fact:
-            openshift_images_after: "{{ os_registry_is_result_after.stdout_lines }} + {{ os_pod_is_result_after.stdout_lines }}"
-
-        - name: "Scorecard test"
+        - name: "Operator deployment and scorecard/imagesource tests"
           block:
-            - name: "Find all extracted CRs from alm-examples"
-              shell: "find \"{{ scorecard_cr_dir }}\" -name \"*.cr.yaml\" -print"
-              register: scorecard_cr_files_result
-              when:
-                - run_scorecard|bool
-                - run_deploy|bool
-
-            - name: "Run scorecard tests on the deployed operator"
+            - name: "Inject operator scorecard data into the operator metadata"
               include_role:
-                name: operator_scorecard_tests
-              with_items: "{{ scorecard_cr_files_result.stdout_lines }}"
-              loop_control:
-                loop_var: cr_path
-              when:
-                - run_scorecard|bool
-                - run_deploy|bool
-          always:
-            - name: "Get the pod container logs of the operator after running scorecard tests"
-              shell: "{{ oc_bin_path }} get --output=name pods | grep {{ operator_pod_name }} | xargs -I{} {{ oc_bin_path }} logs {} -c {{ operator_container_name }}"
-              register: operator_container_result
-              ignore_errors: true
+                name: inject_scorecard_metadata
+              when: run_scorecard|bool
+
+            - name: "Get all registry images on the OpenShift cluster before deploying the operator"
+              shell: "{{ oc_bin_path }} get is --all-namespaces -o json | jq '.items[].spec.tags[] | select(.from.kind == \"DockerImage\") | .from.name' --raw-output | sort -u"
+              register: os_registry_is_result_before
               environment:
                 KUBECONFIG: "{{ kubeconfig_path }}"
               no_log: true
 
-            - name: "Output the operator container log to a debug file"
-              copy:
-                content: "{{ operator_container_result.stdout }}"
-                dest: "{{ work_dir }}/scorecard-operator-container-debug.txt"
+            - name: "Get all pod images on the OpenShift cluster before deploying the operator"
+              shell: "{{ oc_bin_path }} get pods --all-namespaces -o json | jq '.items[].spec.containers[].image' --raw-output | sort -u"
+              register: os_pod_is_result_before
+              environment:
+                KUBECONFIG: "{{ kubeconfig_path }}"
+              no_log: true
+
+            - set_fact:
+                openshift_images_before: " {{ os_registry_is_result_before.stdout_lines }} + {{ os_pod_is_result_before.stdout_lines }}"
+
+            - name: "Deploy the operator on the OpenShift 4.0 cluster with OLM"
+              include_role:
+                name: deploy_olm_operator
+              when: run_deploy|bool
+
+            - name: "Get all openshift registry images"
+              shell: "{{ oc_bin_path }} get is --all-namespaces -o json | jq '.items[].spec.tags[] | select(.from.kind == \"DockerImage\") | .from.name' --raw-output | sort -u"
+              register: os_registry_is_result_after
+              environment:
+                KUBECONFIG: "{{ kubeconfig_path }}"
+              no_log: true
+
+            - name: "Get all OpenShift pod images"
+              shell: "{{ oc_bin_path }} get pods --all-namespaces -o json | jq '.items[].spec.containers[].image' --raw-output | sort -u"
+              register: os_pod_is_result_after
+              environment:
+                KUBECONFIG: "{{ kubeconfig_path }}"
+              no_log: true
+
+            - set_fact:
+                openshift_images_after: "{{ os_registry_is_result_after.stdout_lines }} + {{ os_pod_is_result_after.stdout_lines }}"
+
+            - name: "Scorecard test"
+              block:
+                - name: "Find all extracted CRs from alm-examples"
+                  shell: "find \"{{ scorecard_cr_dir }}\" -name \"*.cr.yaml\" -print"
+                  register: scorecard_cr_files_result
+                  when:
+                    - run_scorecard|bool
+                    - run_deploy|bool
+
+                - name: "Run scorecard tests on the deployed operator"
+                  include_role:
+                    name: operator_scorecard_tests
+                  with_items: "{{ scorecard_cr_files_result.stdout_lines }}"
+                  loop_control:
+                    loop_var: cr_path
+                  when:
+                    - run_scorecard|bool
+                    - run_deploy|bool
+              always:
+                - name: "Get the pod container logs of the operator after running scorecard tests"
+                  shell: "{{ oc_bin_path }} get --output=name pods | grep {{ operator_pod_name }} | xargs -I{} {{ oc_bin_path }} logs {} -c {{ operator_container_name }}"
+                  register: operator_container_result
+                  ignore_errors: true
+                  environment:
+                    KUBECONFIG: "{{ kubeconfig_path }}"
+                  no_log: true
+
+                - name: "Output the operator container log to a debug file"
+                  copy:
+                    content: "{{ operator_container_result.stdout }}"
+                    dest: "{{ work_dir }}/scorecard-operator-container-debug.txt"
+                  when:
+                    - operator_container_result.stdout != ""
+
+            - name: "Test image sources of containers introduced with the testing operator"
+              include_role:
+                name: operator_imagesource_test
+              vars:
+                operator_images: "{{ openshift_images_after | difference(openshift_images_before) | list }}"
               when:
-                - operator_container_result.stdout != ""
+                - run_imagesource|bool
+                - run_deploy|bool
+          when:
+            - run_deploy|bool
+          always:
+            - name: "Cleanup created resources on the OCP cluster"
+              include_role:
+                name: cleanup_operator_resources
+              when:
+                - run_cleanup|bool
+                - run_deploy|bool
 
-        - name: "Test image sources of containers introduced with the testing operator"
-          include_role:
-            name: operator_imagesource_test
-          vars:
-            operator_images: "{{ openshift_images_after | difference(openshift_images_before) | list }}"
-          when:
-            - run_imagesource|bool
-            - run_deploy|bool
-      when:
-        - run_deploy|bool
-      always:
-        - name: "Cleanup created resources on the OCP cluster"
-          include_role:
-            name: cleanup_operator_resources
-          when:
-            - run_cleanup|bool
-            - run_deploy|bool
-
-        - name: "Remove the quay release of the test operator in the testing namespace"
-          shell: "curl -s -H \"Authorization: basic {{ quay_token }}\" -X DELETE https://quay.io/cnr/api/v1/packages/{{ quay_namespace }}/{{ package_name }}-test/{{ quay_release }}/helm"
-          when:
-            - quay_release is defined
-            - package_name is defined
-            - run_cleanup|bool
-            - run_deploy|bool
-          no_log: true
+            - name: "Remove the quay release of the test operator in the testing namespace"
+              shell: "curl -s -H \"Authorization: basic {{ quay_token }}\" -X DELETE https://quay.io/cnr/api/v1/packages/{{ quay_namespace }}/{{ package_name }}-test/{{ quay_release }}/helm"
+              when:
+                - quay_release is defined
+                - package_name is defined
+                - run_cleanup|bool
+                - run_deploy|bool
+              no_log: true
+      when: (distro_type is undefined) or (distro_type != "upstream")

--- a/operator-scorecard-test.yml
+++ b/operator-scorecard-test.yml
@@ -13,7 +13,7 @@
     operator_sdk_bin_path: "/usr/local/bin/operator-sdk"
     jq_bin_path: "/usr/bin/jq"
     yq_bin_path: "/usr/local/bin/yq"
-    oc_bin_path: "oc"
+    oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
     check_scorecard_results: false
 
   tasks:

--- a/roles/build_upstream_catalog/defaults/main.yml
+++ b/roles/build_upstream_catalog/defaults/main.yml
@@ -1,0 +1,4 @@
+operator_work_dir: /tmp/cvp/operator-files
+operator_repo: /tmp/community-operators
+check_verify_result: true
+catalog_repo_dir: /tmp/community-operators-for-catalog

--- a/roles/build_upstream_catalog/tasks/main.yml
+++ b/roles/build_upstream_catalog/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: "Git clone community operators"
+  git:
+    repo: 'https://github.com/operator-framework/community-operators.git'
+    dest: "{{ catalog_repo_dir }}"
+    version: master
+    force: true
+
+- name: "Copy Dockerfile"
+  template:
+    src: "upstream.Dockerfile"
+    dest: "/tmp/upstream.Dockerfile"
+
+- name: "Clear old build log"
+  file:
+    path: "/tmp/build.log"
+    state: absent
+
+- name: "Run catalog build"
+  shell: "docker build --build-arg PERMISSIVE_LOAD=false -f /tmp/upstream.Dockerfile -t operatorhub-catalog:dev {{ catalog_repo_dir }} > /tmp/build.log"
+  register: build_image_output
+
+#temporary for testing
+- name: "Quay login"
+  shell: "docker login -u=\"{{ quay_namespace }}+test\" -p={{ quay_token }} quay.io"
+  no_log: True
+
+#temporary for testing
+- name: "Quay tag"
+  shell: "docker tag operatorhub-catalog:dev quay.io/{{ quay_namespace }}/catalog"
+
+#temporary for testing
+- name: "Quay push"
+  shell: "docker push quay.io/{{ quay_namespace }}/catalog"

--- a/roles/build_upstream_catalog/templates/upstream.Dockerfile
+++ b/roles/build_upstream_catalog/templates/upstream.Dockerfile
@@ -1,0 +1,12 @@
+FROM quay.io/operator-framework/upstream-registry-builder:v1.5.6 as builder
+ARG PERMISSIVE_LOAD=true
+COPY upstream-community-operators manifests
+RUN if [ $PERMISSIVE_LOAD = "true" ] ; then ./bin/initializer --permissive -o ./bundles.db ; else ./bin/initializer -o ./bundles.db ; fi
+
+FROM scratch
+COPY --from=builder /build/bundles.db /bundles.db
+COPY --from=builder /build/bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
+CMD ["--database", "/bundles.db"]

--- a/roles/cleanup_operator_resources/defaults/main.yml
+++ b/roles/cleanup_operator_resources/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-oc_bin_path: oc
+oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
 olm_operator_files_path: "{{ playbook_dir }}/../../operators/olm-operator-files"
 openshift_namespace: test-operator

--- a/roles/deploy_olm_operator/defaults/main.yml
+++ b/roles/deploy_olm_operator/defaults/main.yml
@@ -1,4 +1,4 @@
-oc_bin_path: oc
+oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
 openshift_namespace: test-operator
 current_channel: alpha
 operator_work_dir: /home/jenkins/agent/test-operator

--- a/roles/install_docker/defaults/main.yml
+++ b/roles/install_docker/defaults/main.yml
@@ -1,0 +1,6 @@
+operator_work_dir: /tmp/cvp/operator-files
+operator_repo: /tmp/community-operators
+check_verify_result: true
+catalog_repo_dir: /tmp/community-operators-for-catalog
+docker_user_no_sudo: ubuntu
+

--- a/roles/install_docker/tasks/main.yml
+++ b/roles/install_docker/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: "Install aptitude using apt"
+  apt: name=aptitude state=latest update_cache=yes force_apt_get=yes
+  become: yes
+
+- name: "Install required system packages"
+  apt: name={{ item }} state=latest update_cache=yes
+  loop: [ 'apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'python3-pip', 'virtualenv', 'python3-setuptools']
+  become: yes
+
+- name: "Add Docker GPG apt Key"
+  apt_key:
+    url: https://download.docker.com/linux/ubuntu/gpg
+    state: present
+  become: yes
+
+- name: "Add Docker Repository"
+  apt_repository:
+    repo: deb https://download.docker.com/linux/ubuntu bionic stable
+    state: present
+  become: yes
+
+- name: "Update apt and install docker-ce"
+  apt: update_cache=yes name=docker-ce state=latest
+  become: yes
+
+- name: "Enable Docker without sudo"
+  shell: "usermod -aG docker {{ docker_user_no_sudo }}"
+  become: yes

--- a/roles/install_operator_prereqs/tasks/main.yml
+++ b/roles/install_operator_prereqs/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - set_fact:
     operator_sdk_bin_path: "{{ testing_bin_path}}/operator-sdk"
-    oc_bin_path: "{{ testing_bin_path}}/oc"
+    oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else \"{{ testing_bin_path }}/oc\" }}"
     jq_bin_path: "{{ testing_bin_path }}/jq"
     yq_bin_path: "{{ testing_bin_path }}/yq"
     go_bin_path: "{{ testing_bin_path }}/go/bin/go"
@@ -19,6 +19,7 @@
     src: "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/{{ oc_version }}/openshift-client-linux-{{ oc_version }}.tar.gz"
     dest: "{{ testing_bin_path }}"
     remote_src: yes
+  when: (distro_type is undefined) or (distro_type != "upstream")
 
 - name: "Download and extract go binary to {{ testing_bin_path }}"
   unarchive:
@@ -102,4 +103,37 @@
   when:
     - bundle_image is defined
     - bundle_image != ""
+
+- fail: msg="Please define something like -e 'KIND_VER=v0.7.0'"
+  when: (distro_type == "upstream") and (KIND_ver == '')
+
+- fail: msg="Please define something like -e 'KIND_KUBE_VER=v1.17.0'"
+  when: (distro_type == "upstream") and (KIND_kube_ver == '')
+
+- name: "Install KIND {{ KIND_ver }}"
+  block:
+    - name: "Download KIND"
+      shell: "curl -Lo {{ KIND_bin_path }} https://github.com/kubernetes-sigs/kind/releases/download/{{ KIND_ver }}/kind-linux-amd64"
+
+    - name: "chmod"
+      file:
+        path: "{{ KIND_bin_path }}"
+        mode: +x
+
+    - name: "Check KIND cluster"
+      shell: "{{ KIND_bin_path }} get clusters"
+      register: cluster_found
+      ignore_errors: yes
+
+    - name: "Start KIND"
+      shell: "{{ KIND_bin_path }} create cluster --name operator-test --wait 1m --image kindest/node:{{ KIND_kube_ver }} --verbosity 1"
+      when: cluster_found.stdout != "operator-test"
+
+    - name: "Install kubectl"
+      snap:
+        name: kubectl
+        classic: yes
+      become: yes
+
+  when: (distro_type == "upstream")
 

--- a/ubi-check.yml
+++ b/ubi-check.yml
@@ -14,10 +14,19 @@
   vars:
     openshift_namespace: "test-operator"
     work_dir: "{{ lookup('env', 'WORKSPACE') }}"
-    oc_bin_path: "oc"
+    oc_bin_path: "{{ '/snap/bin/kubectl' if (distro_type == 'upstream') else 'oc' }}"
     pod_name: "cvp-ubi-check"
 
   tasks:
+  - name: "Login to the testing OpenShift instance"
+    shell: "{{ oc_bin_path }} login {{ openshift_url }} --token={{ openshift_token }} --insecure-skip-tls-verify"
+    register: login_result
+    retries: 10
+    delay: 10
+    until: login_result.rc == 0
+    no_log: true
+    when: (distro_type is undefined) or (distro_type != "upstream")
+
   - name: "Create the spec file"
     template:
       src: "ubi-check-pod.yml.j2"


### PR DESCRIPTION
Hi CVP team,

we are extending playbook support for upstream. It will have all features at the end. Currently we support upstream catalog build. More features are coming.

Commit contains:
docker install
quay login for upstream catalog push
docker install
KIND install
KIND start
kubectl installed
replaced oc with kubectl for upstream