### PR TITLE
Add operator bundle basic sanity tests to the parsing role

### DIFF
--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -2,3 +2,4 @@ jq_bin_path: jq
 yq_bin_path: yq
 skopeo_bin_path: skopeo
 operator_work_dir: /home/jenkins/agent/test-operator
+bundle_sanity_checks: true

--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -1,4 +1,10 @@
 ---
+# Note: we probably want to make this more robust in the future to make a sliding scale that can be adjusted on the fly based on configuration?
+- name: "Verify ocp versions are valid"
+  fail:
+    msg: "com.redhat.openshift.versions must only contain v4.5"
+  when: (ocp_versions|length==0) or (ocp_versions|length>1) or ocp_versions[0] != "v4.5"
+
 - name: "Read the variables from annotations.yaml"
   include_vars:
     file: "{{ operator_work_dir }}/metadata/annotations.yaml"

--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -1,0 +1,47 @@
+---
+- name: "Read the variables from annotations.yaml"
+  include_vars:
+    file: "{{ operator_work_dir }}/metadata/annotations.yaml"
+    name: annotations_vars
+
+- debug:
+    var: skopeo_inspect_json.Labels
+
+- debug:
+    var: annotations_vars.annotations
+
+- name: "Check if the operators.operatorframework.io.bundle.channel.default.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operatorframework.io.bundle.channel.default.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.channel.default.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1']
+
+- name: "Check if the operators.operatorframework.io.bundle.channels.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operators.operatorframework.io.bundle.channels.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.channels.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1']
+
+- name: "Check if the operators.operatorframework.io.bundle.manifests.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operators.operatorframework.io.bundle.manifests.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.manifests.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.manifests.v1']
+
+- name: "Check if the operators.operatorframework.io.bundle.mediatype.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operatorframework.io.bundle.mediatype.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.mediatype.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.mediatype.v1']
+
+- name: "Check if the operators.operatorframework.io.bundle.metadata.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operatorframework.io.bundle.metadata.v1 value in the annotations yaml doesn't match the corresponding bundle image label!!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.metadata.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.metadata.v1']
+
+- name: "Check if the operators.operatorframework.io.bundle.package.v1 from annotation.yaml matches the bundle image label"
+  fail:
+    msg: "The operators.operatorframework.io.bundle.package.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.package.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1']

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -22,13 +22,6 @@
     ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
     is_backport: false
 
-# Note: we probably want to make this more robust in the future to make a sliding scale that can be adjusted on the fly based on configuration?
-- name: "verify ocp versions are valid"
-  fail:
-    msg: "com.redhat.openshift.versions must only contain v4.5"
-  when: (ocp_versions|length==0) or (ocp_versions|length>1) or ocp_versions[0] != "v4.5"
-
-
 - set_fact:
     is_backport: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.backport'] }}"
   when: skopeo_inspect_json.Labels['com.redhat.delivery.backport'] is defined

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -102,3 +102,8 @@
   template:
     src: "parsed_operator_data.yml.j2"
     dest: "{{ work_dir }}/parsed_operator_data.yml"
+
+- name: "Sanity check the operator bundle's information"
+  include_tasks: "bundle_sanity_checks.yml"
+  when:
+    bundle_sanity_checks|bool


### PR DESCRIPTION
Operator bundle images have their basic info stored in two places:

* Bundle image labels
* The metadata/annotations.yaml file on the bundle image

Since this information is read from different places by diffrerent components, it is crucial that this data is exactly equal in both locations.

Move the OCP versions validation to the bundle sanity checks.