### PR TITLE
Bugfix: Skip extraction of alm examples

### DIFF
--- a/roles/inject_scorecard_metadata/tasks/main.yml
+++ b/roles/inject_scorecard_metadata/tasks/main.yml
@@ -48,16 +48,37 @@
   environment:
     PATH: "{{ testing_bin_path}}:{{ lookup('env', 'PATH') }}"
 
-- name: "Extract only the first CR from alm-examples in the CSV"
-  shell: "{{ yq_bin_path }} r {{ csv_path }} \"metadata.annotations.alm-examples\" | {{ jq_bin_path }} -c .[0] | {{ yq_bin_path }} w - \"metadata.namespace\" \"{{ openshift_namespace }}\" > {{ scorecard_cr_dir }}/first.cr.yaml"
-  when: scorecard_first_cr|bool
+- name: "Load CSV into a csv_vars"
+  include_vars:
+    file: "{{ csv_path }}"
+    name: csv_vars
 
-- name: "Extract all CRs from alm-examples in the CSV"
-  shell: |
-    source /tmp/community-operators/scripts/lib/file
-    create_cr_files_from_metadata {{ csv_path }} {{ scorecard_cr_dir }} {{ openshift_namespace }}
-  args:
-    executable: /bin/bash
-  environment:
-    PATH: "{{ testing_bin_path}}:{{ lookup('env', 'PATH') }}"
-  when: scorecard_first_cr|bool == false
+- name: "Get spec from csv_vars"
+  set_fact:
+    csv_vars_spec: "{{ csv_vars['spec'] | default({}) }}"
+
+- name: "Get customresourcedefinitions from csv_vars_spec"
+  set_fact:
+    csv_vars_spec_crds: "{{ csv_vars_spec['customresourcedefinitions'] | default({}) }}"
+
+- name: "Get owned attribute from csv_vars_spec_crds"
+  set_fact:
+    csv_vars_spec_crds_owned: "{{ csv_vars_spec_crds['owned'] | default([]) }}"
+
+  # RUNS the following block only when csv_vars_spec_crds_owned is not empty
+- name: "Extract CR only when the CRs defined"
+  block:
+    - name: "Extract only the first CR from alm-examples in the CSV"
+      shell: "{{ yq_bin_path }} r {{ csv_path }} \"metadata.annotations.alm-examples\" | {{ jq_bin_path }} -c .[0] | {{ yq_bin_path }} w - \"metadata.namespace\" \"{{ openshift_namespace }}\" > {{ scorecard_cr_dir }}/first.cr.yaml"
+      when: scorecard_first_cr|bool
+
+    - name: "Extract all CRs from alm-examples in the CSV"
+      shell: |
+        source /tmp/community-operators/scripts/lib/file
+        create_cr_files_from_metadata {{ csv_path }} {{ scorecard_cr_dir }} {{ openshift_namespace }}
+      args:
+        executable: /bin/bash
+      environment:
+        PATH: "{{ testing_bin_path}}:{{ lookup('env', 'PATH') }}"
+      when: scorecard_first_cr|bool == false
+  when: csv_vars_spec_crds_owned | length > 0


### PR DESCRIPTION
fixes #9 
Skip extraction when the csv_path operator spec does not
contain any customresourcedefinitions