### PR TITLE
Bugfix: Fix incorrect CSV in Operator metadata preparation test

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -65,7 +65,7 @@
     register: kind_custerserviceversion_file_paths
 
   - name: "Grep paths with current_csv ClusterServiceVersion"
-    shell: "grep -l {{ current_csv }} {{ item.path }}"
+    shell: "grep -l 'name: {{ current_csv }}' {{ item.path }}"
     with_items: "{{ kind_custerserviceversion_file_paths['files'] }}"
     register: grep_output_current_csv
     ignore_errors: true


### PR DESCRIPTION
The Current version of playbooks was translated literally from the previous playbooks
which contains the following logic:
The current_csv_path and current_csv_dir are determined by
grepping the current_csv version from the existing directory
structure.
ref: https://github.com/redhat-operator-ecosystem/operator-test-playbooks/blob/master/roles/parse_operator_metadata/tasks/main.yml#L67

However, When multiple occurrences of the {{ current_csv }}
was not handled.
The above task roughly translates to ie.,

```
grep "redhat-marketplace-operator.v0.1.1" data_work_dir/0.1.1/redhat-marketplace-operator.v0.1.1.clusterserviceversion.yaml data_work_dir/0.0.1/redhat-marketplace-operator.v0.0.1.clusterserviceversion.yaml data_work_dir/0.1.2/redhat-marketplace-operator.v0.1.2.clusterserviceversion.yaml data_work_dir/0.0.2/redhat-marketplace-operator.v0.0.2.clusterserviceversion.yaml data_work_dir/0.1.0/redhat-marketplace-operator.v0.1.0.clusterserviceversion.yaml

data_work_dir/0.1.1/redhat-marketplace-operator.v0.1.1.clusterserviceversion.yaml:  name: redhat-marketplace-operator.v0.1.1
data_work_dir/0.1.2/redhat-marketplace-operator.v0.1.2.clusterserviceversion.yaml:  replaces: redhat-marketplace-operator.v0.1.1

```
Ideally, there should be only one occurrence.
To achieve this, we might have to search with key: value pair
instead of just the current_csv name
As you can see the occurrence of "replaces: redhat-marketplace-operator.v0.1.1"
is causing a bug where the csv_path and csv_dir are incorrect since Ansible is considering the latest entry first.
However, if we grep for only "name: {{ current_csv }}" we should be getting
only one result.
The following commit will fix the above bug.