### PR TITLE
Fix for the syntax error on "operator-metadata-preparation-bundle-image test"

### DIFF
--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
-- name: "Inspect the bundle image with skopeo"
-  shell: "skopeo inspect {{ image_protocol }}{{ bundle_image }}"
-  register: skopeo_inspect_result
+- name: "Parsing the operator bundle data"
+  block:
+  - name: "Inspect the bundle image with skopeo"
+    shell: "skopeo inspect {{ image_protocol }}{{ bundle_image }}"
+    register: skopeo_inspect_result
 
   - name: "Save the skopeo inspect output to a log file"
     copy:


### PR DESCRIPTION
"operator-metadata-preparation-bundle-image test" is failing for the syntax error [here](http://external-ci-coldstorage.datahub.redhat.com/cvp/cvp-redhat-operator-bundle-image-validation-test/cluster-logging-operator-bundle-container-v4.3.28.202007021904.p0-3/c21dcd4f-5ecf-4226-8816-5b1dbcfedc8c/operator-metadata-preparation-bundle-image-output.txt)