### PR TITLE
Always run bundle validation, add check for presence of required labels

### DIFF
--- a/local-test-operator-bundle.yml
+++ b/local-test-operator-bundle.yml
@@ -84,3 +84,4 @@
         name: cleanup_operator_resources
       when:
         - run_cleanup|bool
+        - run_upstream|bool

--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -4,3 +4,8 @@ skopeo_bin_path: skopeo
 image_protocol: "docker://"
 operator_work_dir: /home/jenkins/agent/test-operator
 bundle_sanity_checks: true
+required_labels:
+  - 'operators.operatorframework.io.bundle.package.v1'
+  - 'operators.operatorframework.io.bundle.channel.default.v1'
+  - 'operators.operatorframework.io.bundle.channels.v1'
+  - 'com.redhat.openshift.versions'

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -17,9 +17,30 @@
     set_fact:
       skopeo_inspect_json: "{{ skopeo_inspect_result.stdout | from_json }}"
 
+  - name: "Verify required labels"
+    block:
+      - name: "Set the failed labels to an empty string and is_bundle_image to false"
+        set_fact:
+          failed_labels: ""
+          is_bundle_image: false
+
+      - name: "If the required label is not found among the image labels, add it to the failed_labels"
+        set_fact:
+          failed_labels: "{{ failed_labels }} {{ item }}"
+        when: item not in skopeo_inspect_json.Labels
+        loop: "{{ required_labels }}"
+
+      - name: "Fail if any of the required operator bundle image label(s) are not found"
+        fail:
+          msg: "Required operator bundle image label(s) not found: {{ failed_labels }}"
+        when: failed_labels != ""
+
+      - name: "If the image contains all of the required labels for a bundle image, set the is_bundle_image to true"
+        set_fact:
+          is_bundle_image: true
+
   - name: "Set the main operator bundle info as parsed from the bundle image labels"
     set_fact:
-      is_bundle_image: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.operator.bundle'] }}"
       package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
       default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
       channels: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1'].split(',') }}"

--- a/roles/validate_operator_bundle/tasks/main.yml
+++ b/roles/validate_operator_bundle/tasks/main.yml
@@ -14,13 +14,18 @@
 
 - name: "Set bundle_validate variable"
   set_fact:
-        bundle_validate: '{{ "{{ bundle_image }}" if run_upstream else "{{ operator_work_dir }}" }}'
+    bundle_validate: "{{ bundle_image }}"
+  when: run_upstream|bool
+
+- name: "Set bundle_validate variable"
+  set_fact:
+    bundle_validate: "{{ operator_work_dir }}"
+  when: not run_upstream|bool
 
 - name: "Validate the operator bundle manifest and metadata with operator-sdk bundle validate"
   shell: "{{ operator_sdk_bin_path }} bundle validate --verbose {{ bundle_validate }} > {{ work_dir}}/validation-output.txt 2>&1"
   register: sdk_validation_result
   ignore_errors: true
-  when: run_upstream|bool
 
 - name: "Output the return code of operator-sdk bundle validate command to a debug file"
   copy:


### PR DESCRIPTION
Reimplements #33, along with additional changes to the local-test-operator-bundle.yml
* Add check for presence of required labels when parsing bundle images
* Remove requirement for the `com.redhat.delivery.operator.bundle` label
* Always run the operator-sdk bundle validation
* Skip resource cleanup when not running for upstream operators 