### PR TITLE
parse_operator_metadata - recurse to find pkg path

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -6,6 +6,7 @@
       paths: "{{ operator_work_dir }}"
       file_type: file
       contains: 'packageName'
+      recurse: true
     register: package_path_result
 
     # assuming only one file matches the file path


### PR DESCRIPTION
When running `parse-operator-metadata.yml`, the `operator_work_dir` extra-var is specified to indicate the directory where metadata files reside. The `find` module needs to recurse so as to discover the package file if the metadata is contained a sub directory of `operator_work_dir`.
