### PR TITLE
Using the already extracted bundle for inspect to skip hitting 504

### DIFF
--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -3,6 +3,7 @@ yq_bin_path: yq
 skopeo_bin_path: skopeo
 image_protocol: "docker://"
 operator_work_dir: /home/jenkins/agent/test-operator
+operator_bundle_dir: /home/jenkins/agent/operator-bundle
 bundle_sanity_checks: true
 required_labels:
   - 'operators.operatorframework.io.bundle.package.v1'

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -1,8 +1,9 @@
 ---
 - name: "Parsing the operator bundle data"
   block:
+    ## Must use this in conjunction with extract bundle
   - name: "Inspect the bundle image with skopeo"
-    shell: "skopeo inspect {{ image_protocol }}{{ bundle_image }}"
+    shell: "skopeo inspect oci:{{ operator_bundle_dir }}:latest"
     register: skopeo_inspect_result
 
   - name: "Save the skopeo inspect output to a log file"


### PR DESCRIPTION
* Once we pull the bundle we don't need the registry anymore.