### PR TITLE
[CVP-1320] Add check for mediatype.v1 label

### DIFF
--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -13,3 +13,4 @@ required_labels:
 valid_ocp_versions:
   - "v4.5"
   - "v4.6"
+label_mediatype_v1_expected_value: 'registry+v1'

--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -55,6 +55,12 @@
   when:
     - annotations_vars.annotations['operators.operatorframework.io.bundle.mediatype.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.mediatype.v1']
 
+- name: "Check if the operators.operatorframework.io.bundle.mediatype.v1 is set to the expected value"
+  fail:
+    msg: "The operators.operatorframework.io.bundle.mediatype.v1 value doesn't match the expected value \"{{ label_mediatype_v1_expected_value }}\""
+  when:
+    - annotations_vars.annotations['operators.operatorframework.io.bundle.mediatype.v1'] != label_mediatype_v1_expected_value
+
 - name: "Check if the operators.operatorframework.io.bundle.metadata.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operatorframework.io.bundle.metadata.v1 value in the annotations yaml doesn't match the corresponding bundle image label!!"


### PR DESCRIPTION
Add check to verify `operators.operatorframework.io.bundle.mediatype.v1` label value is `registry+v1` for operator bundle images.