### PR TITLE
Add support for OCP version 4.7 for operator bundle images

### DIFF
--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -13,4 +13,5 @@ required_labels:
 valid_ocp_versions:
   - "v4.5"
   - "v4.6"
+  - "v4.7"
 label_mediatype_v1_expected_value: 'registry+v1'


### PR DESCRIPTION
Since the OCP version 4.6 is GA, the v4.7 is entering the pre-release stage. As part of that, the operator playbooks will need to support the new version in the operator bundle testing process