### PR TITLE
Update the operator-sdk version

### DIFF
--- a/roles/install_operator_prereqs/defaults/main.yml
+++ b/roles/install_operator_prereqs/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 testing_bin_path: /tmp/cvp/bin
-operator_sdk_version: v0.15.1
+operator_sdk_version: v1.3.0
 oc_version: 4.4.13  # The catalog initialization test requires oc v4.4+
 operator_courier_version: 2.1.9
 go_version: 1.13.7

--- a/roles/install_operator_prereqs/tasks/main.yml
+++ b/roles/install_operator_prereqs/tasks/main.yml
@@ -39,7 +39,7 @@
 
 - name: "Install operator-sdk"
   get_url:
-    url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk-{{ operator_sdk_version }}-x86_64-linux-gnu
+    url: https://github.com/operator-framework/operator-sdk/releases/download/{{ operator_sdk_version }}/operator-sdk_linux_amd64
     dest: "{{ operator_sdk_bin_path }}"
     mode: "0755"
   tags:

--- a/roles/validate_operator_bundle/tasks/main.yml
+++ b/roles/validate_operator_bundle/tasks/main.yml
@@ -23,7 +23,7 @@
   when: not run_upstream|bool
 
 - name: "Validate the operator bundle manifest and metadata with operator-sdk bundle validate"
-  shell: "{{ operator_sdk_bin_path }} bundle validate --verbose {{ bundle_validate }} > {{ work_dir}}/validation-output.txt 2>&1"
+  shell: "{{ operator_sdk_bin_path }} bundle validate --select-optional name=operatorhub --verbose {{ bundle_validate }} > {{ work_dir}}/validation-output.txt 2>&1"
   register: sdk_validation_result
   ignore_errors: true
 


### PR DESCRIPTION
Update `operator-sdk` to be able to use the new optional validator parameter `--select-optional operatorhub`.