### PR TITLE
[CVP-1452] Make CVP/operator-metadata-preparation should handle number in package file correctly

### DIFF
--- a/filter_plugins/determine_clusterservice_version.py
+++ b/filter_plugins/determine_clusterservice_version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import pprint
+
+
+def determine_csv(channels, current_channel):
+    """
+    params
+    channels: list of dictionaries of channels
+    current_channel: searched channel name
+    """
+    pprint.pprint(channels)
+    pprint.pprint(current_channel)
+    result = []
+    for channel in channels:
+        if str(channel['name']) == str(current_channel):
+            result.append(channel['currentCSV'])
+    return result
+
+
+class FilterModule(object):
+    ''' A filter to fetch current clusterserviceversion '''
+    def filters(self):
+        return {
+            'determine_clusterservice_version': determine_csv
+        }

--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -73,10 +73,12 @@
 
   - name: "Determine the current clustersourceversion for the operator channel"
     set_fact:
-      current_csv : "{{ package_vars['channels'] | json_query(query) }}"
-    vars:
-      query: "[?name=='{{ current_channel }}'].currentCSV"
-    failed_when: current_csv | length == 0
+      current_csv: "{{ package_vars['channels'] | determine_clusterservice_version(current_channel) }}"
+
+  - name: "Fail when current clusterServiceVersion is null"
+    fail:
+      msg: "Failed to determine the current clusterServiceVersion found empty array as follows {{ current_csv }}"
+    when: current_csv | length == 0
 
   - name: "Get current_csv from current_csv query output"
     set_fact:


### PR DESCRIPTION
Fixes CVP-1452 partly
Working on another fix to manage outputs of playbooks clearly. 

Regardless of versioning make operator-metadata-preparation should handle number in the package file correctly