### PR TITLE
Modify bundle parsing role to not slice the ocp versions label

### DIFF
--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -1,12 +1,4 @@
 ---
-- name: "Verify ocp versions are valid"
-  fail:
-    msg: "the label com.redhat.openshift.versions can not contain {{ item }}"
-  loop: "{{ ocp_versions }}"
-  when: 
-    - item not in valid_ocp_versions
-    - not run_upstream|bool
-
 - name: "Read the variables from annotations.yaml"
   include_vars:
     file: "{{ operator_work_dir }}/metadata/annotations.yaml"

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -45,7 +45,7 @@
       package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
       default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
       channels: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1'].split(',') }}"
-      ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'].split(',') }}"
+      ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'] }}"
       # if backport label missing, an empty is_backport means not set.
       is_backport: ""
 

--- a/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
+++ b/roles/parse_operator_bundle/templates/parsed_operator_data.yml.j2
@@ -21,11 +21,4 @@ crd_paths:
   - {{ crd_path }}
 {% endfor %}
 {% endif %}
-{% if ocp_versions|length < 1 %}
-ocp_versions: []
-{% else %}
-ocp_versions:
-{% for ocp_version in ocp_versions %}
-  - {{ ocp_version }}
-{% endfor %}
-{% endif %}
+ocp_versions: {{ ocp_versions }}


### PR DESCRIPTION
* Modify bundle parsing role to not slice the com.redhat.openshift.versions label
* Remove the sanity tests for operator bundle's ocp_versions