### PR TITLE
[CVP-1510] Bugfix: Detect error for CSV mismatch and also display the better error message for the same.

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -17,7 +17,12 @@
     set_fact:
       package_path: "{{ package_path_result.files[0].path }}"
     ignore_errors: true
+    register: set_package_path_output
 
+  - name: "Fail due to package_path not set"
+    fail:
+      msg: "Failed due to package_path not found. package_path_result found is as follows {{ package_path_result }}"
+    when: set_package_path_output.failed
 
   - name: "Load variables from package path into variable package_vars"
     include_vars:
@@ -209,7 +214,7 @@
         parse_operator_metadata_results: {'result': 'fail', 'msg': "{{ ansible_failed_result }}" }
 
     - name: "Fail the play with the results"
-      fail:
+      debug:
         msg: "{{ parse_operator_metadata_results }}"
 
   always:

--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -8,7 +8,7 @@
       contains: 'packageName'
     register: package_path_result
 
-  - name: debug
+  - name: "Display the package path result"
     debug:
       msg: "{{ package_path_result }}"
 
@@ -16,6 +16,8 @@
   - name: "set variable for package_path from package_path_result"
     set_fact:
       package_path: "{{ package_path_result.files[0].path }}"
+    ignore_errors: true
+
 
   - name: "Load variables from package path into variable package_vars"
     include_vars:
@@ -108,6 +110,13 @@
     set_fact:
       csv_path: "{{ current_csv_path }}"
       current_csv_dir: "{{ current_csv_path | dirname }}"
+    ignore_errors: true
+    register: set_fact_csv_path_dir_output
+
+  - name: "Fail if the current csv path is not found"
+    fail:
+      msg: "Unable to find the current csv path please check the csv names in metadata"
+    when: set_fact_csv_path_dir_output.failed
 
   - name: "Determine the package path in the operator metadata directory"
     find:

--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -1,6 +1,10 @@
 - name: "Running Prepare operator metadata"
   block:
 
+  - name: "Set crd_paths to collect crd_paths"
+    set_fact:
+      crd_paths: []
+
   - name: "Determine the package path inside operator metadata directory"
     find:
       paths: "{{ operator_work_dir }}"
@@ -222,3 +226,7 @@
       copy:
         content: "{{ parse_operator_metadata_results | to_nice_json }}" 
         dest: parse_operator_metadata_results.json
+    - name: "Output all collected data to a yaml file in work dir"
+      template:
+        src: "parsed_operator_data.yml.j2"
+        dest: "{{ work_dir }}/parsed_operator_data.yml"

--- a/roles/parse_operator_metadata/templates/parsed_operator_data.yml.j2
+++ b/roles/parse_operator_metadata/templates/parsed_operator_data.yml.j2
@@ -2,15 +2,15 @@ package_name: {{ package_name }}
 package_path: {{ package_path }}
 current_channel: {{ current_channel }}
 current_csv: {{ current_csv }}
-current_csv_dir: {{ current_csv_dir }}
-csv_path: {{ csv_path }}
-operator_pod_name: {{ operator_pod_name }}
-operator_capabilities: {{ operator_capabilities }}
-operator_container_name: {{ operator_container_name }}
-operator_allnamespaces_support: {{ operator_allnamespaces_support }}
-operator_ownnamespace_support: {{ operator_ownnamespace_support }}
-operator_singlenamespace_support: {{ operator_singlenamespace_support }}
-operator_multinamespace_support: {{ operator_multinamespace_support }}
+current_csv_dir: {{ current_csv_dir | default('Error finding current_csv_dir') }}
+csv_path: {{ csv_path | default('Error finding csv_path') }}
+operator_pod_name: {{ operator_pod_name | default('Error finding operator_pod_name') }}
+operator_capabilities: {{ operator_capabilities | default('Error finding operator_capabilites') }}
+operator_container_name: {{ operator_container_name | default('Error finding operator_container_name') }}
+operator_allnamespaces_support: {{ operator_allnamespaces_support | default('Error finding operator_container_name') }}
+operator_ownnamespace_support: {{ operator_ownnamespace_support | default('Error finding operator_container_name') }}
+operator_singlenamespace_support: {{ operator_singlenamespace_support | default('Error finding operator_container_name') }}
+operator_multinamespace_support: {{ operator_multinamespace_support | default('Error finding operator_container_name') }}
 {% if crd_paths|length < 1 %}
 crd_paths: []
 {% else %}


### PR DESCRIPTION
Fixes bug which results in nongeneration parse_operator_metadata.json incase of mismatch inside the CSV 
Further also displays a better message for debugging purposes. 
Now the current console logs looks as follows: 
```
TASK [parse_operator_metadata : Fail if the current csv path is not found] *****
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:116
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": "Unable to find the current csv path please check the csv names in metadata"
}

TASK [parse_operator_metadata : Rescue block contains the error messages] ******
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:195
ok: [localhost] => {
    "msg": "Rescue block has found an error, The following are details of failed task."
}

TASK [parse_operator_metadata : FAILED task name in ansible is as follows:] ****
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:199
ok: [localhost] => {
    "msg": "Fail if the current csv path is not found"
}

TASK [parse_operator_metadata : Result of failed task] *************************
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:203
ok: [localhost] => {
    "msg": {
        "changed": false,
        "failed": true,
        "msg": "Unable to find the current csv path please check the csv names in metadata"
    }
}

TASK [parse_operator_metadata : Set failure result] ****************************
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:207
ok: [localhost] => {
    "ansible_facts": {
        "parse_operator_metadata_results": {
            "msg": {
                "changed": false,
                "failed": true,
                "msg": "Unable to find the current csv path please check the csv names in metadata"
            },
            "result": "fail"
        }
    },
    "changed": false
}

TASK [parse_operator_metadata : Fail the play with the results] ****************
task path: /home/srallaba/workspace/cvp_1510/operator-test-playbooks/roles/parse_operator_metadata/tasks/main.yml:211
fatal: [localhost]: FAILED! => {
    "changed": false,
    "msg": {
        "msg": {
            "changed": false,
            "failed": true,
            "msg": "Unable to find the current csv path please check the csv names in metadata"
        },
        "result": "fail"
    }
}


```

Also generates the parse_operator_metadata.json with failure message. 
refer: cvp-1510 to test this fix. 
