### PR TITLE
Collect the names of images that were pulled during the operator deployment tests

### DIFF
--- a/local-test-operator.yml
+++ b/local-test-operator.yml
@@ -21,6 +21,7 @@
     testing_bin_path: "{{ work_dir }}/bin"
     current_channel: '' # Added to avoid a potential bug with undefined variables
     olm_ver: 0.14.1
+    events_file_path: "{{ work_dir }}/events.json"
 
   environment:
     PATH: "{{ ansible_env.PATH }}:{{ ansible_env.HOME }}/.local/bin"
@@ -150,9 +151,27 @@
             openshift_images_before: " {{ os_registry_is_result_before.stdout_lines }} + {{ os_pod_is_result_before.stdout_lines }}"
           when: not run_upstream|bool
 
+        - name: "Set the deployment start time"
+          shell: "date -u '+%Y-%m-%dT%H:%M:%SZ'"
+          register: start_time
+          when:
+            - run_deploy|bool
+            - not run_upstream|bool
+
         - name: "Deploy the operator on the OpenShift 4.0 with OLM"
           include_role:
             name: deploy_olm_operator
+          when:
+            - run_deploy|bool
+            - not run_upstream|bool
+
+        - name: "Collect the names of the images modified during the deployment"
+          include_role:
+            name: collect_modified_images
+          vars:
+            deployment_start_time: "{{ start_time }}"
+            events_file_path: "{{ events_file_path }}"
+            kubeconfig_path: "{{ kubeconfig_path }}"
           when:
             - run_deploy|bool
             - not run_upstream|bool

--- a/roles/collect_modified_images/defaults/main.yml
+++ b/roles/collect_modified_images/defaults/main.yml
@@ -1,0 +1,3 @@
+pulled_images: []
+events_file_path: /tmp/events.json
+deployment_start_time: 1970-01-01T00:00:00Z

--- a/roles/collect_modified_images/tasks/main.yml
+++ b/roles/collect_modified_images/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# # In order for this role to work, add the following task to your playbook
+# # immediately before calling the deployment role.
+# - name: "Set the deployment start time"
+#   shell: "date -u '+%Y-%m-%dT%H:%M:%SZ'"
+#   register: deployment_start_time
+# 
+# The above shell command gets the date in the same format passed by openshift
+# in the `oc get events` command below.  The below command gets all images
+# pulled to the cluster.  This includes images that were not pulled as part of
+# the deployment.  deployment_start time is used in the parse_image_names file
+# to filter out images pulled before the deployment started.  Since this role
+# should be run immediately after the deployment, there should be no need to filter
+# images pulled after the deployment.
+
+
+
+- name: "Generate events.json"
+  shell: "{{ oc_bin_path }} {% raw %}get events --all-namespaces --field-selector reason==Pulling -o go-template='{{range .items}}{{.lastTimestamp}},{{.message}}{{\"\\n\"}}{{end}}'{% endraw %}"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  register: events
+
+- name: "get list of images in events.json"
+  include_tasks: parse_image_names.yml
+  with_items:
+    - "{{ events.stdout_lines }}"
+
+- name: "Print images"
+  debug:
+    msg: "pulled images: {{ pulled_images }}"
+
+- name: "Save images to file"
+  module: copy
+  content: "{{ pulled_images | to_json }}"
+  dest: "{{ events_file_path }}"
+  delegate_to: localhost

--- a/roles/collect_modified_images/tasks/parse_image_names.yml
+++ b/roles/collect_modified_images/tasks/parse_image_names.yml
@@ -1,0 +1,24 @@
+# Once the `oc get events` command in tasks/main.yml is run, we will end up
+# with a list of timestamps and pulling messages in CSV format.  main.yml will
+# pass each line into this file for parsing, so "item" will be formatted as
+# follows:
+#
+# 2021-02-15T14:14:19Z,pulling image "docker-registry.default.svc:5000/cvp-ci/cvp-slave:stable"
+#
+# The timestamp is obviously the first item here
+# The second item is the message from which we get the image name.
+# This is hacky, but unfortunately it's the only way to do it right now.
+# The "item.split(',')[1][15:-1]" below gets the substring that contains the
+# image name.  item.split(',')[1] get the message from the item.  [15] is the
+# index of the character after the first quotation mark.  [-1] moves in one
+# character from the right of the string, which chops off the quotation mark at
+# the end of the array.
+- name: "split item"
+  set_fact:
+    timestamp: "{{ item.split(',')[0] }}"
+    image: "{{ item.split(',')[1][15:-1] }}"
+
+- name: "parse and return image name when timestamp is after start_time"
+  set_fact:
+    pulled_images: "{{ pulled_images + [image] }}"
+  when: "{{ timestamp > deployment_start_time }}"


### PR DESCRIPTION
We currently determine which images were pulled during operator deployment during the operator image source test in CVP, but this approach doesn't work if the tests are run on an external cluster.  These changes save a file with a list of images that were pulled during the deployment test so that the image source test can simply reference the file.

Although the legacy operator deployment test won't be run externally, it still needed to be modified in preparation for the changes that will be made downstream.  This also allows us to implement these changes before the new bundle operator deployment playbooks are complete.