### PR TITLE
[CVP-1610] Fix Operator metadata parsing role which doesn't account for quotes in CSV name

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -104,7 +104,7 @@
     register: kind_custerserviceversion_file_paths
 
   - name: "Grep paths with current_csv ClusterServiceVersion"
-    shell: "grep -l 'name: {{ current_csv }}' {{ item.path }}"
+    shell: "grep -lE \"name: '{{ current_csv }}'|name: {{ current_csv }}\" {{ item.path }}"
     with_items: "{{ kind_custerserviceversion_file_paths['files'] }}"
     register: grep_output_current_csv
     ignore_errors: true


### PR DESCRIPTION
The parse-operator-metadata role fails when CSV name is in quotes. 
This PR fixes it. 
example 
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  name: 'xxxv.6.0'
```
Try, 
```
ansible-playbook -vvvv -i "localhost," --connection=local parse-operator-metadata.yml -e "operator_work_dir=<path to metadata dir>" -e"work_dir=/tmp/test_op/" # any temp dir
```
Actual output of parse_operator_metadata_results.json
```
{
    "msg": {
        "_ansible_no_log": false,
        "changed": false,
        "failed": true,
        "msg": "Unable to find the current csv path please check the csv names in metadata"
    },
    "result": "fail"
}
```

expected output: 
```
{
    "msg": "",
    "result": "pass"
}
```