### PR TITLE
Ignore CR deletion timeout

### DIFF
--- a/roles/operator_scorecard_tests/tasks/main.yml
+++ b/roles/operator_scorecard_tests/tasks/main.yml
@@ -31,10 +31,12 @@
 - debug:
     msg: "Scorecard Basic Tests passed: {{ scorecard_results_passed_result.stdout }}"
 
+  # The scorecard test may have already deleted the CR, so ignore any errors
 - name: "Delete the operator CR"
   shell: "{{ oc_bin_path }} delete -f {{ cr_path }} --ignore-not-found=true --grace-period=60 --timeout=120s"
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
+  ignore_errors: true
 
 - name: "Fail if the operator didn't satisfy the Basic Tests requirement"
   fail:


### PR DESCRIPTION
Made a simple change to ignore errors caused by a hung CR deletion after the scorecard test. The error is not related to the test and allows the playbook to continue and gather all the logs intact.