### PR TITLE
[CVP-1713] Add a playbook for parsing collected image pull events

### DIFF
--- a/parse-collected-images.yml
+++ b/parse-collected-images.yml
@@ -1,0 +1,18 @@
+---
+- name: "Parse the collected image pull events"
+  hosts: all
+  become: false
+  gather_facts: false
+
+  vars:
+    run_upstream: false
+    operator_work_dir: "/home/jenkins/agent/test-operator"
+    work_dir: "{{ lookup('env', 'WORKSPACE') }}"
+    collect_pull_events: false
+
+  tasks:
+    - name: "Parse the collected image pull events"
+      include_role:
+        name: collect_modified_images
+      vars:
+        events_file_path: "{{ work_dir }}/image_pull_events.json"

--- a/roles/collect_modified_images/defaults/main.yml
+++ b/roles/collect_modified_images/defaults/main.yml
@@ -1,3 +1,4 @@
 pulled_images: []
 events_file_path: /tmp/events.json
 deployment_start_time: 1970-01-01T00:00:00Z
+collect_pull_events: true

--- a/roles/collect_modified_images/files/optional-operators-cvp-common-test-commands.sh
+++ b/roles/collect_modified_images/files/optional-operators-cvp-common-test-commands.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# Collect all image pull events from the testing cluster
+# The output will contain the timestamp and the event message
+# in a comma-separated value format
+
+PULL_EVENTS_ART="${ARTIFACT_DIR}/image_pull_events.csv"
+echo "Collecting all image pull events from the testing cluster in ${PULL_EVENTS_ART}"
+oc get events --all-namespaces --field-selector reason==Pulling -o go-template='{{range .items}}{{.lastTimestamp}},{{.message}}{{"\n"}}{{end}}' > "${PULL_EVENTS_ART}"

--- a/roles/collect_modified_images/tasks/main.yml
+++ b/roles/collect_modified_images/tasks/main.yml
@@ -13,25 +13,33 @@
 # should be run immediately after the deployment, there should be no need to filter
 # images pulled after the deployment.
 
+- name: "Set the output CSV file location"
+  set_fact:
+    image_pull_events: "{{ work_dir }}/image_pull_events.csv"
+  when: image_pull_events is not defined
 
-
-- name: "Generate events.json"
-  shell: "{{ oc_bin_path }} {% raw %}get events --all-namespaces --field-selector reason==Pulling -o go-template='{{range .items}}{{.lastTimestamp}},{{.message}}{{\"\\n\"}}{{end}}'{% endraw %}"
+- name: "Collect the image pull events from the cluster in a CSV format"
+  shell: "{{ lookup('file', 'optional-operators-cvp-common-test-commands.sh') }}"
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
-  register: events
+    ARTIFACT_DIR: "{{ work_dir }}"
+  when: collect_pull_events|bool
 
-- name: "get list of images in events.json"
+- name: "Read the resulting file and split it by lines"
+  set_fact:
+    image_pull_events_lines: "{{ lookup('file', image_pull_events).splitlines() }}"
+
+- name: "Filter the list of images in the image_pull_events.csv by timestamp"
   include_tasks: parse_image_names.yml
   with_items:
-    - "{{ events.stdout_lines }}"
+    - "{{ image_pull_events_lines }}"
 
-- name: "Print images"
+- name: "Print filtered images"
   debug:
     msg: "pulled images: {{ pulled_images }}"
 
-- name: "Save images to file"
-  module: copy
-  content: "{{ pulled_images | to_json }}"
-  dest: "{{ events_file_path }}"
+- name: "Save images to an output json file"
+  copy:
+    content: "{{ pulled_images | to_json }}"
+    dest: "{{ events_file_path }}"
   delegate_to: localhost


### PR DESCRIPTION
Add a new playbook to the operator-test-playbooks for parsing the collected image pull events which will be used in the operator image source test.

* Add the DPTP shell script for collecting pull events
* Add the option to use pre-collected image pull events
* Add the playbook for CVP usage
