### PR TITLE
[CVP-1683] Failed when CSV.metadata.annotations['alm-examples'] is set to empty

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -152,6 +152,15 @@
       csv_vars: "{{ csv_data.stdout }}"
     when: not run_upstream|bool
 
+  - name: "Set facts for csv_data alm-examples"
+    set_fact:
+      csv_alm_examples: "{{ (csv_vars | from_yaml).metadata.annotations['alm-examples'] }}"
+
+  - name: "Fail when alm-examples are set to empty"
+    fail:
+      msg: "Failed due to CSV.metadata.annotations['alm-examples'] is set to empty"
+    when: csv_alm_examples | length == 0
+
   - name: "Determine and setfact for podname"
     set_fact:
       operator_pod_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].name }}"


### PR DESCRIPTION
Bugfix: 
Currently, when an ISV operator has the `metadata.annotations.alm-examples` CSV field as empty, the operator-sdk scorecard (which expects the field to contain CR examples in JSON form) fails when trying to run.
the following PR fixes the above issue. 
