### PR TITLE
Bugfix: fix failure with alm-examples when not specified in metadata

### DIFF
--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -154,7 +154,7 @@
 
   - name: "Set facts for csv_data alm-examples"
     set_fact:
-      csv_alm_examples: "{{ (csv_vars | from_yaml).metadata.annotations['alm-examples'] }}"
+      csv_alm_examples: "{{ (csv_vars | from_yaml).metadata.annotations['alm-examples'] | default([]) }}"
 
   - name: "Fail when alm-examples are set to empty"
     fail:


### PR DESCRIPTION
The previous bugfix does not consider the case when the alm-examples key is not specified in data. 
The following bugfix handles it.