### PR TITLE
[CVP-1753] Remove support for encrypted kube objects with CVP ssh key

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,20 +72,8 @@ we can set the `run_prereqs` parameter in this way: ``-e run_prereqs=false``
 
 The kube_objects is a kubernetes resource requires to be injected to the openshift cluster.
 
-The kube_objects can be passed as a parameter to the playbook
+The gpg encoded kube_objects can be passed as a parameter to the playbook
 for example: `-e kube_objects=kube_objects`
-
-##### 2. A shared symmetric key
-
-If the kube_objects is a secret and in the encrypted form, a shared symmetric key is required to decrypt the kube_objects.
-
-The symmetric_key can be passed as a parameter to the playbook
-for example: `-e symmetric_key=symmetric_key`
-
-##### 3. The RSA private key is required to decrypt the symmetric key
-
-The path where the private key is stored can be supplied as `rsa_private_key` parameter,
-for example: `-e rsa_private_key=~/.ssh/private_key`
 
 ### Selecting operator tests
 
@@ -139,9 +127,7 @@ ansible-playbook -vv -i "localhost," --connection=local local-test-operator.yml 
     -e quay_namespace="${QUAY_NAMESPACE}" \
     -e production_quay_namespace="certified-operators" \
     -e operator_dir="${OPERATOR_DIR}" \
-    -e kube_objects="${KUBE_OBJECTS}" \
-    -e symmetric_key="${SYMMETRIC_KEY}" \
-    -e rsa_private_key="${PRIVATE_KEY}"
+    -e kube_objects="${KUBE_OBJECTS}"
 ```
 
 #### 3. Testing community operators

--- a/roles/deploy_olm_operator/tasks/main.yml
+++ b/roles/deploy_olm_operator/tasks/main.yml
@@ -44,8 +44,6 @@
         - name: "include_role"
           include_role:
             name: inject_openshift_kube_objects
-          vars:
-            rsa_private_key: "{{ lookup('env', 'HOME') }}/.ssh/private_key"
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
       when:

--- a/roles/deploy_olm_operator_upstream/tasks/main.yml
+++ b/roles/deploy_olm_operator_upstream/tasks/main.yml
@@ -66,8 +66,6 @@
       - name: "Inject openshift kube_objects"
         include_role:
           name: inject_openshift_kube_objects
-        vars:
-          rsa_private_key: "{{ lookup('env', 'HOME') }}/.ssh/private_key"
     environment:
       KUBECONFIG: "{{ kubeconfig_path }}"
     when:

--- a/roles/inject_openshift_kube_objects/defaults/main.yml
+++ b/roles/inject_openshift_kube_objects/defaults/main.yml
@@ -3,6 +3,4 @@ kube_objects_dir: "/home/jenkins/agent/kube_objects"
 # Assumed that real values will be passed in for these:
 kube_objects: kube_objects
 kubeconfig_path: "$WORKSPACE/operators/ocp-cluster-deployment/${clusterName}/auth/kubeconfig"
-rsa_private_key: rsa_private_key
 openshift_namespace: default
-symmetric_key: symmetric_key

--- a/roles/inject_openshift_kube_objects/tasks/main.yml
+++ b/roles/inject_openshift_kube_objects/tasks/main.yml
@@ -5,40 +5,11 @@
     state: directory
     mode: '0755'
 
-- name: "Decrypt the kube_objects if it's RSA encoded"
-  when: "not '-----BEGIN PGP MESSAGE-----' in kube_objects"
-  block:
-    - name: "Decode the symmetric key received from the user"
-      shell: "echo \"{{ symmetric_key }}\" | base64 --decode > {{ kube_objects_dir }}/get_sym_key"
-      no_log: true
+- name: "Read the PGP encoded kube_objects and store them in a file"
+  shell: "echo \"{{ kube_objects }}\" > {{ kube_objects_dir }}/get_kubeObjects.txt"
 
-    - name: "Decrypt the symmetric key using RSA private key"
-      shell: "openssl rsautl -decrypt -oaep -inkey {{ rsa_private_key }} -in {{ kube_objects_dir }}/get_sym_key -out {{ kube_objects_dir }}/secret.key"
-
-    - name: "Verify the shared symmetric key"
-      shell: "stat -c %s {{ kube_objects_dir }}/secret.key"
-      register: symmetric_key_size
-
-    - name: "Fail if the shared symmetric key is not 32 bytes"
-      fail:
-        msg: "The decrypted shared symmetric key is {{ symmetric_key_size.stdout }} bytes. The shared key should be of 32 bytes"
-      when: symmetric_key_size.stdout != "32"
-
-    - name: "Read the encrypted kube_objects decode and store them in a file"
-      shell: "echo \"{{ kube_objects }}\" | tr \" \" \"\n\" | base64 --decode > {{ kube_objects_dir }}/get_kubeObjects.txt"
-      no_log: true
-
-    - name: "Decrypt the kube_objects through the shared symmetric key"
-      shell: "openssl aes-256-cbc -d -in {{ kube_objects_dir }}/get_kubeObjects.txt -out {{ kube_objects_dir }}/kube_objects.yaml -pass file:{{ kube_objects_dir }}/secret.key"
-
-- name: "Decrypt the kube_objects if it's PGP encoded."
-  when: "'-----BEGIN PGP MESSAGE-----' in kube_objects"
-  block:
-    - name: "Read the encrypted kube_objects, decode and store them in a file"
-      shell: "echo \"{{ kube_objects }}\" > {{ kube_objects_dir }}/get_kubeObjects.txt"
-
-    - name: "Decrypt the kube_objects using the gpg key"
-      shell: "gpg --decrypt {{ kube_objects_dir }}/get_kubeObjects.txt > {{ kube_objects_dir }}/kube_objects.yaml"
+- name: "Decode the kube_objects using the gpg key"
+  shell: "gpg --decrypt {{ kube_objects_dir }}/get_kubeObjects.txt > {{ kube_objects_dir }}/kube_objects.yaml"
 
 - name: "Create the kube_objects on the testing openshift cluster for operator certification"
   shell: "oc apply -f {{ kube_objects_dir }}/kube_objects.yaml"


### PR DESCRIPTION
This is to remove the support for the old RSA encryption method of the kube objects