### PR TITLE
Fix output dir for store the result in a JSON file

### DIFF
--- a/roles/optional-operators-subscribe/tasks/main.yml
+++ b/roles/optional-operators-subscribe/tasks/main.yml
@@ -34,6 +34,6 @@
   always:
   - name: "Store the result in a JSON file"
     copy:
-      dest: "optional_operator_subscribe.json"
+      dest: "{{ ARTIFACT_DIR }}/optional_operator_subscribe.json"
       content: "{{ shell_script_output }}"
       mode: 0644


### PR DESCRIPTION
In optional operators subscribe the task "Store the result in a json file"
does not specify the ARTIFACT_DIR.  This may fail if the current working
directory is not writable and we can't find it if it's not in the
ARTIFACT_DIR.