### PR TITLE
[CVP-1890] Add the overlayfs to storage options in github actions

### DIFF
--- a/.github/workflows/build_and_push_image_on_tag.yml
+++ b/.github/workflows/build_and_push_image_on_tag.yml
@@ -15,7 +15,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    env:
+      # Fixes https://github.com/actions/virtual-environments/issues/3080
+      STORAGE_OPTS: overlay.mount_program=/usr/bin/fuse-overlayfs
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/build_and_push_latest_image.yml
+++ b/.github/workflows/build_and_push_latest_image.yml
@@ -17,7 +17,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    env:
+      # Fixes https://github.com/actions/virtual-environments/issues/3080
+      STORAGE_OPTS: overlay.mount_program=/usr/bin/fuse-overlayfs
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/build_and_test_midstream_image.yml
+++ b/.github/workflows/build_and_test_midstream_image.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    env:
+      # Fixes https://github.com/actions/virtual-environments/issues/3080
+      STORAGE_OPTS: overlay.mount_program=/usr/bin/fuse-overlayfs
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/build_and_test_upstream_ci_image.yml
+++ b/.github/workflows/build_and_test_upstream_ci_image.yml
@@ -13,7 +13,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
+    env:
+      # Fixes https://github.com/actions/virtual-environments/issues/3080
+      STORAGE_OPTS: overlay.mount_program=/usr/bin/fuse-overlayfs
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Set the STORAGE_OPTIONS environment variable in github actions to enable building images with podman.
This resolves the podman build failures occuring with the latest version used in the github actions virtual environment.