### PR TITLE
[CVP-1923] Don't fail when alm-examples are not defined

### DIFF
--- a/.github/workflows/build_and_test_upstream_ci_image.yml
+++ b/.github/workflows/build_and_test_upstream_ci_image.yml
@@ -26,8 +26,9 @@ jobs:
         run: |
           podman --version
           podman build -t upstream_ci_image:latest -f Dockerfiles/ci/Dockerfile --build-arg OPERATOR_SDK_VERSION=v1.4.0
-      - name: "Run example operator-metadata through upstream_ci_image --> negative test"
+
+      - name: "Run example operator-metadata with missing alm-examples through upstream_ci_image --> positive test"
         continue-on-error: false
         run: |
           mkdir test_operator_work_dir output_logs
-          podman run -it -v $PWD:/project/operator-test-playbooks -v ./Dockerfiles/ci/example-metadata-without-alm-annotations:/project/operator_dir -v ./output_logs:/project/output -v ./test_operator_work_dir:/project/test_operator_work_dir -e TEST_NAME=test_for_report_failed_empty_alm_examples -e OPERATOR_DIR=/project/operator_dir -e WORK_DIR=/project/output -e OPERATOR_WORK_DIR=/project/test_operator_work_dir/ upstream_ci_image:latest
+          podman run -it -v $PWD:/project/operator-test-playbooks -v ./Dockerfiles/ci/example-metadata-without-alm-annotations:/project/operator_dir -v ./output_logs:/project/output -v ./test_operator_work_dir:/project/test_operator_work_dir -e TEST_NAME=test_for_report_success_empty_alm_examples -e OPERATOR_DIR=/project/operator_dir -e WORK_DIR=/project/output -e OPERATOR_WORK_DIR=/project/test_operator_work_dir/ upstream_ci_image:latest

--- a/Dockerfiles/ci/run_tests.py
+++ b/Dockerfiles/ci/run_tests.py
@@ -19,7 +19,7 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
         self.playbooks_dir = os.getenv('PLAYBOOKS_DIR',
                                        "/project/operator-test-playbooks/")
 
-    def test_for_report_failed_empty_alm_examples(self):
+    def test_for_report_success_empty_alm_examples(self):
         exec_cmd = "ansible-playbook -vvv -i localhost, --connection local \
                     operator-test-playbooks/prepare-operator-metadata.yml \
                     -e 'operator_dir={operator_dir}' \
@@ -33,9 +33,7 @@ class RunOperatorTestPlaybookTests(unittest.TestCase):
         with open("{}/parse_operator_metadata_results.json".format(self.playbooks_dir), "r") as fd:
             result_output = json.load(fd)
             print(result_output)
-            fail_msg = "Failed due to CSV.metadata.annotations['alm-examples'] is set to empty"
-            self.assertIn(fail_msg,
-                          result_output["msg"]["msg"])
+            self.assertEqual(result_output["result"], "pass")
 
 if __name__ == '__main__':
     unittest.main()

--- a/local-test-operator.yml
+++ b/local-test-operator.yml
@@ -62,7 +62,7 @@
       file:
         path: "{{ scorecard_cr_dir }}"
         state: directory
-        mode: 0644
+        mode: 0744
       when:
         - run_scorecard|bool
         - not run_upstream|bool

--- a/roles/parse_operator_metadata/tasks/main.yml
+++ b/roles/parse_operator_metadata/tasks/main.yml
@@ -152,15 +152,6 @@
       csv_vars: "{{ csv_data.stdout }}"
     when: not run_upstream|bool
 
-  - name: "Set facts for csv_data alm-examples"
-    set_fact:
-      csv_alm_examples: "{{ (csv_vars | from_yaml).metadata.annotations['alm-examples'] | default([]) }}"
-
-  - name: "Fail when alm-examples are set to empty"
-    fail:
-      msg: "Failed due to CSV.metadata.annotations['alm-examples'] is set to empty"
-    when: csv_alm_examples | length == 0
-
   - name: "Determine and setfact for podname"
     set_fact:
       operator_pod_name: "{{ (csv_vars | from_yaml).spec.install.spec.deployments[0].name }}"


### PR DESCRIPTION
* Remove check for alm-examples from metadata parsing
* Update the CI unit tests according to the new logic
* Change the file permissions in local test playbook to fix local testing