### PR TITLE
[CVP-1899]-setting exit status code & error msg

### DIFF
--- a/.github/workflows/build_and_test_midstream_image.yml
+++ b/.github/workflows/build_and_test_midstream_image.yml
@@ -31,45 +31,9 @@ jobs:
           podman --version
           cd Dockerfiles/midstream/
           podman build -t midstream_image:latest -f Dockerfile --build-arg OPERATOR_SDK_VERSION=v1.4.0
-      - name: "Run example operator-metadata through midstream ci image  --> positive test"
+
+      - name: "Run unit tests"
         continue-on-error: false
         run: |
-          mkdir ./output_logs
-          podman run -it -v $PWD:/project/operator-test-playbooks -v ./output_logs:/project/output midstream_image:latest
-
-      - name: "Run example operator-metadata through midstream ci image  --> negative parsing test"
-        continue-on-error: true
-        run: |
-          rm -rf ./output_logs
-          mkdir ./output_logs
-          podman run -it -v $PWD:/project/operator-test-playbooks -v ./output_logs:/project/output -e IMAGE_TO_TEST=quay.io/cvpops/test-operator:missing-alm-examples-v1 midstream_image:latest
-
-      - name: "Succeed if the negative test fails"
-        continue-on-error: false
-        if: ${{ failure() }}
-        run: |
-          exit 0
-
-      - name: "Fail if the previous job skips"
-        if: ${{ cancelled() }}
-        run: |
-          exit 0
-
-      - name: "Run example operator-metadata through midstream ci image  --> negative operator-sdk validation test"
-        continue-on-error: true
-        run: |
-          rm -rf ./output_logs
-          mkdir ./output_logs
-          podman run -it -v $PWD:/project/operator-test-playbooks -v ./output_logs:/project/output -e IMAGE_TO_TEST=quay.io/cvpops/test-operator:invalid-dependencies-v1 midstream_image:latest
-
-      - name: "Succeed if the negative test fails"
-        continue-on-error: false
-        if: ${{ failure() }}
-        run: |
-          exit 0
-
-      - name: "Fail if the previous job skips"
-        if: ${{ cancelled() }}
-        run: |
-          exit 0
+          podman run -it -v $PWD:/project/operator-test-playbooks midstream_image:latest python3 /unit_tests.py
 

--- a/Dockerfiles/midstream/Dockerfile
+++ b/Dockerfiles/midstream/Dockerfile
@@ -14,4 +14,5 @@ RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm6
     dnf install --setopt=install_weak_deps=False -y git-core ansible skopeo && \
     dnf clean all
 ADD ./run_tests.py /run_tests.py
+ADD ./unit_tests.py /unit_tests.py
 CMD ["/run_tests.py"]

--- a/Dockerfiles/midstream/README.md
+++ b/Dockerfiles/midstream/README.md
@@ -1,6 +1,14 @@
 # operator-bundle-validate-container
 CVP midstream operator bundle validate container
 
+## Prerequisites
+
+In order to run unit_tests.py on your local without any issues, you need to make sure 
+you run the command with specific options. 
+Here is an example of running the unit_tests.py locally
+`sudo podman run -it -v $PWD:/project/operator-test-playbooks:z <midstream_image> /unit_tests.py`
+First thing you reckon is that you are running this command directly from upstream repo `operator-test-playbooks` and you have build your own midstream_image locally from Dockerfiles/midstream/Dockerfile.
+
 # Usage
 
 ## Building image on local machine 

--- a/Dockerfiles/midstream/run_tests.py
+++ b/Dockerfiles/midstream/run_tests.py
@@ -6,7 +6,8 @@ import unittest
 import subprocess
 from os import path
 
-class RunMidstreamCVPTests(unittest.TestCase):
+
+class RunMidstreamCVPTests():
 
     def setUp(self):
         self.operator_dir = os.getenv('OPERATOR_DIR',
@@ -17,8 +18,7 @@ class RunMidstreamCVPTests(unittest.TestCase):
                                   "/project/output/")
         self.playbooks_dir = os.getenv('PLAYBOOKS_DIR',
                                        "/project/operator-test-playbooks/")
-        self.image_to_test = os.getenv('IMAGE_TO_TEST',
-                                       'quay.io/cvpops/test-operator:v1.0-16')
+        self.image_to_test = os.getenv('IMAGE_TO_TEST')
         self.umoci_bin_path = os.getenv('UMOCI_BIN_PATH',
                                         '/usr/local/bin/umoci')
 
@@ -31,7 +31,7 @@ class RunMidstreamCVPTests(unittest.TestCase):
                                                     operator_work_dir=self.operator_work_dir,
                                                     bundle_image=self.image_to_test,
                                                     umoci_bin_path=self.umoci_bin_path)
-        result = subprocess.run(exec_cmd, shell=True)
+        result = subprocess.run(exec_cmd, shell=True, capture_output=True)
         return result
 
     def run_validate_operator_bundle(self):
@@ -40,26 +40,58 @@ class RunMidstreamCVPTests(unittest.TestCase):
                     -e 'operator_dir={operator_dir}' \
                     -e 'operator_work_dir={operator_work_dir}' \
                     -e 'work_dir={work_dir}'".format(operator_dir=self.operator_dir,
-                                                    operator_work_dir=self.operator_work_dir,
-                                                    work_dir=self.work_dir)
-        result = subprocess.run(exec_cmd, shell=True)
+                                                     operator_work_dir=self.operator_work_dir,
+                                                     work_dir=self.work_dir)
+        result = subprocess.run(exec_cmd, shell=True, capture_output=True)
         return result
 
     def test_for_extract_and_validate_bundle_image(self):
+
+        self.setUp()
+        global exit_code
+        exit_code = 0
+        # check if IMAGE_TO_TEST is defined, return exit_code 102 in case it's not
+        if (self.image_to_test is None):
+            print("Environment variable IMAGE_TO_TEST not set! Stopping the tests.")
+            with open(".errormessage", 'w') as error_msg:
+                print("Result code: 102 Error message: Environment variable IMAGE_TO_TEST not set!", file=error_msg)
+            exit_code = 102
+            return exit_code
+        if (self.operator_dir != '/project/operator_dir/' or
+           self.operator_work_dir != '/project/test_operator_work_dir/' or
+           self.playbooks_dir != '/project/operator-test-playbooks/' or
+           self.umoci_bin_path != '/usr/local/bin/umoci' or
+           self.work_dir != '/project/output/'):
+            print("Environment variable misconfigured!")
+            with open(".errormessage", 'w') as error_msg:
+                print("Result code: 103 Error message: Environment variable was not set correctly!", file=error_msg)
+            exit_code = 103
+            return exit_code
         result = self.run_extract_operator_bundle()
-        self.assertEqual(0,
-                         result.returncode,
-                         "extract-operator-bundle.yml failed")
+        if (result.returncode != 0):
+            print("Ansible playbook extract-operator-bundle.yml failed with result code: %s , see the file .errormessage for more info." % result.returncode)
+            with open(".errormessage", "w") as error_msg:
+                print("Result code: " + str(result.returncode), "Error message: " + str(result.stderr), file=error_msg)
+            exit_code = 50
+            return exit_code
         result = self.run_validate_operator_bundle()
-        self.assertEqual(0,
-                         result.returncode,
-                         "validate-operator-bundle.yml failed")
-        self.assertTrue(path.exists("/project/output/validation-rc.txt"))
-        self.assertTrue(path.exists("/project/output/validation-output.txt"))
-        self.assertTrue(path.exists("/project/output/validation-version.txt"))
+        assert (path.exists("/project/output/validation-rc.txt"))
+        assert (path.exists("/project/output/validation-output.txt"))
+        assert (path.exists("/project/output/validation-version.txt"))
         with open('/project/output/validation-rc.txt', 'r') as reader:
             rc = reader.read()
-            self.assertEqual(0, int(rc), "validation of bundle image failed")
+            if (int(rc) != 0):
+                print("Image bundle validation failed with result code: %s , see /project/output/validation-output.txt file for more info." % int(rc))
+                exit_code = 70
+                return exit_code
+        return 0
 
 if __name__ == '__main__':
-    unittest.main()
+    resultcodes = [0, 50, 70, 102, 103]
+    runTest = RunMidstreamCVPTests()
+    with open("tests_result.log", 'w') as f:
+        if (runTest.test_for_extract_and_validate_bundle_image() not in resultcodes):
+            exit_code = 1
+            print("Error occured during unit tests, please see .errormessage file for more info.")
+            os.rename(r'tests_result.log', r'.errormessage')
+    sys.exit(exit_code)

--- a/Dockerfiles/midstream/unit_tests.py
+++ b/Dockerfiles/midstream/unit_tests.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import unittest
+import os
+import subprocess
+
+
+class Testing(unittest.TestCase):
+    # Running the container with correctly set environment variables, all tasks from run_tests.py should pass
+    def test_default_positive(self):
+        exec_cmd = """
+        export IMAGE_TO_TEST=quay.io/cvpops/test-operator:v1.0-16
+        /run_tests.py
+        """
+        self.assertFalse(os.path.exists(".errormessage"), "File .errormessage should not be present!")
+        result = subprocess.run(exec_cmd, shell=True)
+        self.assertEqual(0, result.returncode)
+
+    # Set env variable to custom made image that makes playbook extract-operator-bundle.yml fail
+    # Due to parsing error
+    def test_negative_parsing(self):
+        exec_cmd = """
+        export IMAGE_TO_TEST=quay.io/cvpops/test-operator:missing-alm-examples-v1
+        /run_tests.py
+        """
+        result = subprocess.run(exec_cmd, shell=True)
+        with open(".errormessage") as error_file:
+            self.assertIn("Result code:", error_file.read(), "Result code not found in %s" % error_file)
+        self.assertEqual(50, result.returncode)
+
+    # Set env variable to custom made image that makes validation fails with following error:
+    # ERRO[0003] error validating format in /tmp/bundle-688328851: Bundle validation errors: couldn't
+    # parse dependency of type olm.crd
+    def test_negative_image_bundle_validation(self):
+        exec_cmd = """
+        export IMAGE_TO_TEST=quay.io/cvpops/test-operator:invalid-dependencies-v1
+        /run_tests.py
+        """
+        result = subprocess.run(exec_cmd, shell=True)
+        with open("/project/output/validation-output.txt") as error_file:
+            self.assertIn("Bundle validation errors: couldn't parse dependency of type olm.crd", error_file.read(), "Result code not found in %s" % error_file)
+        self.assertEqual(70, result.returncode)
+
+    # Don't set env variable IMAGE_TO_TEST case
+    def test_negative_image_to_test_not_set(self):
+        exec_cmd = """
+        /run_tests.py
+        """
+        result = subprocess.run(exec_cmd, shell=True)
+        with open(".errormessage") as error_file:
+            self.assertIn("Result code: 102 Error message: Environment variable IMAGE_TO_TEST not set!", error_file.read(), "Result code not found in %s" % error_file)
+        self.assertEqual(102, result.returncode)
+
+    # Set incorrect env variable UMOCI_BIN_PATH for ansible playbook extract-operator-bundle.yml
+    def test_negative_extract_operator_bundle(self):
+        exec_cmd = """
+        export IMAGE_TO_TEST=quay.io/cvpops/test-operator:v1.0-16
+        export UMOCI_BIN_PATH=/root
+        /run_tests.py
+        """
+        result = subprocess.run(exec_cmd, shell=True)
+        with open(".errormessage") as error_file:
+            self.assertIn("Result code: 103 Error message: Environment variable was not set correctly!", error_file.read(), "Result code not found in %s" % error_file)
+        self.assertEqual(103, result.returncode)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
According to the description, in case of 
Exit code between **50-99** we are letting the user know that the issue occured and where he can find mode explicit description of it.
In case of any other non-zero exit code we save the error message in file as well.
All error messages are saved to files with **.errormessage** extension. Those files are located where the entrypoint script is located.
