### PR TITLE
[CVP-1976] Wait for the operator CSV to be in succeeded phase

### DIFF
--- a/roles/deploy_olm_operator/tasks/main.yml
+++ b/roles/deploy_olm_operator/tasks/main.yml
@@ -234,6 +234,16 @@
         msg: 'Operator deployment with OLM failed, check the olm-*.txt files for more details'
       when: operator_result.rc != 0
 
+    - name: "Wait for the operator CSV {{ current_csv }} to be in the `Succeeded` phase before finishing"
+      shell: "{{ oc_bin_path }} -n {{ openshift_namespace }} get csv {{ current_csv }} -o jsonpath='{.status.phase}' || true"
+      register: operator_csv_phase
+      retries: 90
+      delay: 10
+      until: operator_csv_phase.stdout == "Succeeded"
+      ignore_errors: true
+      environment:
+        KUBECONFIG: "{{ kubeconfig_path }}"
+
   rescue:
 
     - name: "Rescue block contains the error messages"


### PR DESCRIPTION
* Add the wait for CSV to deploy_olm_operator role

In case the OLM deployment of the operator controller pod is successful, wait for the CSV to be in Succeeded phase before continuing testing. 