### PR TITLE
[CVP-1897] Generate mock prow artifacts when running external Operator Bundle Tests

### DIFF
--- a/optional-operators-subscribe.yml
+++ b/optional-operators-subscribe.yml
@@ -2,7 +2,7 @@
 - name: "Run optional operators subscribe"
   hosts: localhost
   become: false
-  gather_facts: false
+  gather_facts: true
 
   tasks:
     - name: "Run optional operators subscribe step"

--- a/roles/optional-operators-subscribe/tasks/main.yml
+++ b/roles/optional-operators-subscribe/tasks/main.yml
@@ -9,6 +9,9 @@
       OO_INSTALL_NAMESPACE: "{{ OO_INSTALL_NAMESPACE | default('') }}"
       OO_TARGET_NAMESPACES: "{{ OO_TARGET_NAMESPACES | default('') }}"
       ARTIFACT_DIR: "{{ ARTIFACT_DIR }}"
+      finished_json_contents:
+        passed: false
+        timestamp: "{{ ansible_date_time.iso8601_basic_short }}"
 
   # incase of failure the following task fails
   # we will be ignoring errors to display the results
@@ -31,9 +34,30 @@
     debug:
       msg: "{{ shell_script_output.stdout_lines }}"
 
+  - name: "Set finished_json_contents in case of success"
+    set_fact:
+      finished_json_contents: "{{ finished_json_contents | combine(new_item, recursive=true) }}"
+    vars:
+      new_item: { 'passed':  true }
+    with_dict: "{{ finished_json_contents }}"
+    when: shell_script_output.rc == 0
+
   always:
+  - name: "Store the result of the shell script output to build-log.txt"
+    copy:
+      dest: "{{ ARTIFACT_DIR }}/build-log.txt"
+      content: "{{ shell_script_output.stdout }}"
+      mode: 0644
+
   - name: "Store the result in a JSON file"
     copy:
       dest: "{{ ARTIFACT_DIR }}/optional_operator_subscribe.json"
       content: "{{ shell_script_output }}"
       mode: 0644
+
+  - name: "Store the finished.json"
+    copy:
+      dest: "{{ ARTIFACT_DIR }}/finished.json"
+      content: "{{ finished_json_contents }}"
+      mode: 0644
+


### PR DESCRIPTION


When operator bundle deployment tests are run through DPTP, two files are generated that the upstream `optional-operators-subscribe` role does not generate.
We will need to generate these files as a part of the `optional-operators-subscribe` role.
The finished.json file should contain the following fields:
timestamp: use the already-existing `start_time` field
passed: boolean true or false
result: Omit. The result field has been deprecated in favor of passed
revision: Omit. The revision field is deprecated
The build-log.txt file is the stdout of the optional-operators-subscribe shell script. We should collect the stdout and save it to the file.
Both files should be saved inside the ARTIFACT_DIR for the role.