### PR TITLE
[CVP-2052] Fix failures when running the midstream-cvp image within an OpenShift pod

### DIFF
--- a/Dockerfiles/midstream/Dockerfile
+++ b/Dockerfiles/midstream/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /project
 ARG OPERATOR_SDK_VERSION=v1.4.0
 ARG OPERATOR_TEST_PLAYBOOKS_TAG=v1.0.11
 ARG UMOCI_VERSION=v0.4.5
+ADD ./entrypoint.sh /entrypoint.sh
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac);\
     export OS=$(uname | awk '{print tolower($0)}');\
     export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/;\
@@ -11,6 +12,7 @@ RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm6
     curl -fL -o /usr/local/bin/umoci https://github.com/opencontainers/umoci/releases/download/${UMOCI_VERSION}/umoci.amd64 && \
     chmod a+x /usr/local/bin/umoci && \
     mkdir /project/output && \
+    chmod g+w /etc/passwd && \
     dnf install --setopt=install_weak_deps=False -y git-core ansible skopeo && \
     dnf clean all
 ADD ./run_tests.py /run_tests.py

--- a/Dockerfiles/midstream/Dockerfile
+++ b/Dockerfiles/midstream/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /project
 ARG OPERATOR_SDK_VERSION=v1.4.0
 ARG OPERATOR_TEST_PLAYBOOKS_TAG=v1.0.11
 ARG UMOCI_VERSION=v0.4.5
-ADD ./entrypoint.sh /entrypoint.sh
+ADD ./fix_etc_passwd.sh /usr/bin/fix_etc_passwd.sh
 RUN export ARCH=$(case $(arch) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(arch) ;; esac);\
     export OS=$(uname | awk '{print tolower($0)}');\
     export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/$OPERATOR_SDK_VERSION/;\

--- a/Dockerfiles/midstream/entrypoint.sh
+++ b/Dockerfiles/midstream/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -e
+main() {
+    local username="${SSH_AUTH_USER:-default}"
+    local home
+    home=$(mk_home "$username")
+    setup_passwd "$username" "$home"
+    exec sleep inf
+}
+mk_home() {
+    local username="${1:?}"
+    [[ -d /workDir ]] && [[ -w /workDir ]] && \
+        mkdir -p "/workDir/home/$username" && \
+        echo "/workDir/home/$username" && \
+        return 0
+    mktemp --tmpdir -d "${username}.XXXXXX"
+}
+setup_passwd() {
+    local username="${1:?}"
+    local home="${2:?}"
+    local uid="$3"
+    local gid="${4:-0}"
+    local passwd=/etc/passwd
+    ! whoami 2>/dev/null || return 0
+    if ! [[ -w "$passwd" ]]; then
+        echo "There is no permission to add user $username to $passwd"
+        return 0
+    fi
+    [[ "$uid" ]] || uid="$(id -u)"
+    echo \
+        "${username}:x:${uid}:${gid}:Default Application User:${home}:/sbin/nologin" \
+        >> /etc/passwd
+}
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/Dockerfiles/midstream/fix_etc_passwd.sh
+++ b/Dockerfiles/midstream/fix_etc_passwd.sh
@@ -4,26 +4,23 @@ main() {
     local home
     home=$(mk_home "$username")
     setup_passwd "$username" "$home"
-    exec sleep inf
 }
 mk_home() {
     local username="${1:?}"
-    [[ -d /workDir ]] && [[ -w /workDir ]] && \
-        mkdir -p "/workDir/home/$username" && \
-        echo "/workDir/home/$username" && \
-        return 0
+    mkdir -p "/tmp/home/$username" && \
+    echo "/tmp/home/$username" && \
+    return 0
     mktemp --tmpdir -d "${username}.XXXXXX"
 }
 setup_passwd() {
     local username="${1:?}"
     local home="${2:?}"
-    local uid="$3"
+    local uid="$(id -u)"
     local gid="${4:-0}"
-    local passwd=/etc/passwd
     ! whoami 2>/dev/null || return 0
-    if ! [[ -w "$passwd" ]]; then
-        echo "There is no permission to add user $username to $passwd"
-        return 0
+    if ! [[ $(getent passwd $uid) ]]; then
+       echo "There is no permission to add user $username to $passwd"
+       return 0
     fi
     [[ "$uid" ]] || uid="$(id -u)"
     echo \

--- a/Dockerfiles/midstream/run_tests.py
+++ b/Dockerfiles/midstream/run_tests.py
@@ -88,6 +88,8 @@ class RunMidstreamCVPTests():
 
 if __name__ == '__main__':
     resultcodes = [0, 50, 70, 102, 103]
+    # run fix_etc_passwd.sh to setup random user generated in openshift
+    subprocess.call(['sh', "/usr/bin/fix_etc_passwd.sh"])
     runTest = RunMidstreamCVPTests()
     with open("tests_result.log", 'w') as f:
         if (runTest.test_for_extract_and_validate_bundle_image() not in resultcodes):


### PR DESCRIPTION
the problem arise from the fact that the container runs within an OpenShift pod in more restrictive manner. For e.g., it doesn’t run as root.

For resolving this issue, we have discussed two alternative solutions:

Using product-ci-cd's entrypoint script:https://code.engineering.redhat.com/gerrit/plugins/gitiles/product-ci-cd/+/refs/heads/master/container/midstream/entrypoint.sh and also adding the following to the Dockerfile: