### PR TITLE
[CVP-2054] Skip checking the bundle.channel.default.v1 operator bundle image label

### DIFF
--- a/roles/parse_operator_bundle/defaults/main.yml
+++ b/roles/parse_operator_bundle/defaults/main.yml
@@ -7,7 +7,6 @@ operator_bundle_dir: /home/jenkins/agent/operator-bundle
 bundle_sanity_checks: true
 required_labels:
   - 'operators.operatorframework.io.bundle.package.v1'
-  - 'operators.operatorframework.io.bundle.channel.default.v1'
   - 'operators.operatorframework.io.bundle.channels.v1'
   - 'com.redhat.openshift.versions'
 valid_ocp_versions:

--- a/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
+++ b/roles/parse_operator_bundle/tasks/bundle_sanity_checks.yml
@@ -23,12 +23,6 @@
 - debug:
     var: annotations_vars.annotations
 
-- name: "Check if the operators.operatorframework.io.bundle.channel.default.v1 from annotation.yaml matches the bundle image label"
-  fail:
-    msg: "The operators.operatorframework.io.bundle.channel.default.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"
-  when:
-    - annotations_vars.annotations['operators.operatorframework.io.bundle.channel.default.v1'] != skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1']
-
 - name: "Check if the operators.operatorframework.io.bundle.channels.v1 from annotation.yaml matches the bundle image label"
   fail:
     msg: "The operators.operators.operatorframework.io.bundle.channels.v1 value in the annotations yaml doesn't match the corresponding bundle image label!"

--- a/roles/parse_operator_bundle/tasks/main.yml
+++ b/roles/parse_operator_bundle/tasks/main.yml
@@ -44,11 +44,11 @@
   - name: "Set the main operator bundle info as parsed from the bundle image labels"
     set_fact:
       package_name: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.package.v1'] }}"
-      default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
       channels: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channels.v1'].split(',') }}"
       ocp_versions: "{{ skopeo_inspect_json.Labels['com.redhat.openshift.versions'] }}"
       # if backport label missing, an empty is_backport means not set.
       is_backport: ""
+      default_channel: ""
 
   - name: "Set the current channel to the first value from the operators.operatorframework.io.bundle.channels.v1 label"
     set_fact:
@@ -58,6 +58,11 @@
     set_fact:
       is_backport: "{{ skopeo_inspect_json.Labels['com.redhat.delivery.backport'] }}"
     when: skopeo_inspect_json.Labels['com.redhat.delivery.backport'] is defined
+
+  - name: "Set default_channel according to the operators.operatorframework.io.bundle.channel.default.v1 label if present."
+    set_fact:
+      default_channel: "{{ skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] }}"
+    when: skopeo_inspect_json.Labels['operators.operatorframework.io.bundle.channel.default.v1'] is defined
 
   - name: "Determine paths with kind ClusterServiceVersion"
     find:


### PR DESCRIPTION
* Don't require bundle.channel.default label in parse_operator_bundle role
* Remove check for default channel in bundle_sanity_checks.yml